### PR TITLE
[feat] #1 - serpAPI로 데이터셋을 수집해 테이블 단위로 분리하여 저장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+application.yml
 application-*.yml
 
 .gradle

--- a/src/main/java/com/github/airmoment/AirmomentApplication.java
+++ b/src/main/java/com/github/airmoment/AirmomentApplication.java
@@ -2,7 +2,11 @@ package com.github.airmoment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+import com.github.airmoment.global.client.serpapi.SerpApiProperties;
+
+@EnableConfigurationProperties(SerpApiProperties.class)
 @SpringBootApplication
 public class AirmomentApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/github/airmoment/flight/domain/FlightLayover.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightLayover.java
@@ -1,0 +1,57 @@
+package com.github.airmoment.flight.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "flight_layover")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FlightLayover {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer layoverOrder;
+
+	@Column(nullable = false, length = 10)
+	private String airportCode;
+
+	@Column(nullable = false)
+	private String airportName;
+
+	@Column(nullable = false)
+	private Integer duration;
+
+	@Column(nullable = false)
+	private Boolean isOvernight;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "flight_offer_id", nullable = false)
+	private FlightOffer flightOffer;
+
+	public static FlightLayover of(FlightOffer flightOffer, Integer layoverOrder,
+		String airportCode, String airportName,
+		Integer duration, Boolean isOvernight) {
+		FlightLayover layover = new FlightLayover();
+		layover.flightOffer = flightOffer;
+		layover.layoverOrder = layoverOrder;
+		layover.airportCode = airportCode;
+		layover.airportName = airportName;
+		layover.duration = duration;
+		layover.isOvernight = isOvernight;
+		return layover;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/FlightOffer.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightOffer.java
@@ -1,0 +1,77 @@
+package com.github.airmoment.flight.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.airmoment.flight.domain.enums.FlightDirection;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "flight_offer")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FlightOffer {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@Column(nullable = false)
+	private Integer totalDuration;
+
+	@Column(nullable = false)
+	private Boolean hasLayover;
+
+	@Column(nullable = false)
+	private Integer layoverCount;
+
+	@Column(nullable = false)
+	private Boolean isBest;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private FlightDirection direction;
+
+	@OneToMany(mappedBy = "flightOffer", cascade = CascadeType.ALL)
+	private List<FlightSegment> flightSegments = new ArrayList<>();
+
+	@OneToMany(mappedBy = "flightOffer", cascade = CascadeType.ALL)
+	private List<FlightLayover> flightLayovers = new ArrayList<>();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "flight_search_id", nullable = false)
+	private FlightSearch flightSearch;
+
+	public static FlightOffer of(FlightSearch flightSearch, Integer price, Integer totalDuration,
+		Boolean hasLayover, Integer layoverCount,
+		Boolean isBest, FlightDirection direction) {
+		FlightOffer flightOffer = new FlightOffer();
+		flightOffer.flightSearch = flightSearch;
+		flightOffer.price = price;
+		flightOffer.totalDuration = totalDuration;
+		flightOffer.hasLayover = hasLayover;
+		flightOffer.layoverCount = layoverCount;
+		flightOffer.isBest = isBest;
+		flightOffer.direction = direction;
+		return flightOffer;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/FlightPriceHistory.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightPriceHistory.java
@@ -1,0 +1,43 @@
+package com.github.airmoment.flight.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "flight_price_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FlightPriceHistory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long timeStamp;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "flight_search_id", nullable = false)
+	private FlightSearch flightSearch;
+
+	public static FlightPriceHistory of(FlightSearch flightSearch, Long timeStamp, Integer price) {
+		FlightPriceHistory history = new FlightPriceHistory();
+		history.flightSearch = flightSearch;
+		history.timeStamp = timeStamp;
+		history.price = price;
+		return history;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/FlightPriceInsight.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightPriceInsight.java
@@ -23,16 +23,16 @@ public class FlightPriceInsight {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private Integer lowestPrice;
 
-	@Column(nullable = false, length = 20)
+	@Column(nullable = true, length = 20)
 	private String priceLevel;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private Integer typicalPriceMin;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private Integer typicalPriceMax;
 
 	@OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/github/airmoment/flight/domain/FlightPriceInsight.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightPriceInsight.java
@@ -1,0 +1,53 @@
+package com.github.airmoment.flight.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "flight_price_insight")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FlightPriceInsight {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer lowestPrice;
+
+	@Column(nullable = false, length = 20)
+	private String priceLevel;
+
+	@Column(nullable = false)
+	private Integer typicalPriceMin;
+
+	@Column(nullable = false)
+	private Integer typicalPriceMax;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "flight_search_id", nullable = false)
+	private FlightSearch flightSearch;
+
+	public static FlightPriceInsight of(FlightSearch flightSearch, Integer lowestPrice,
+		String priceLevel, Integer typicalPriceMin,
+		Integer typicalPriceMax) {
+		FlightPriceInsight insight = new FlightPriceInsight();
+		insight.flightSearch = flightSearch;
+		insight.lowestPrice = lowestPrice;
+		insight.priceLevel = priceLevel;
+		insight.typicalPriceMin = typicalPriceMin;
+		insight.typicalPriceMax = typicalPriceMax;
+		return insight;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/FlightSearch.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightSearch.java
@@ -1,0 +1,69 @@
+package com.github.airmoment.flight.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "flight_search")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FlightSearch {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private LocalDateTime searchedAt;
+
+	@Column(nullable = false, length = 10)
+	private String departureAirportCode;
+
+	@Column(nullable = false, length = 10)
+	private String arrivalAirportCode;
+
+	@Column(nullable = false)
+	private LocalDate outboundDate;
+
+	@Column(nullable = false)
+	private LocalDate returnDate;
+
+	@Column(nullable = true, columnDefinition = "TEXT")
+	private String departureToken;
+
+	@OneToMany(mappedBy = "flightSearch", cascade = CascadeType.ALL)
+	private List<FlightOffer> flightOffers = new ArrayList<>();
+
+	@OneToOne(mappedBy = "flightSearch", cascade = CascadeType.ALL)
+	private FlightPriceInsight flightPriceInsight;
+
+	@OneToMany(mappedBy = "flightSearch", cascade = CascadeType.ALL)
+	private List<FlightPriceHistory> flightPriceHistories = new ArrayList<>();
+
+	public static FlightSearch of(String departureAirportCode, String arrivalAirportCode,
+		LocalDate outboundDate, LocalDate returnDate, String departureToken) {
+		FlightSearch flightSearch = new FlightSearch();
+		flightSearch.searchedAt = LocalDateTime.now();
+		flightSearch.departureAirportCode = departureAirportCode;
+		flightSearch.arrivalAirportCode = arrivalAirportCode;
+		flightSearch.outboundDate = outboundDate;
+		flightSearch.returnDate = returnDate;
+		flightSearch.departureToken = departureToken;
+		return flightSearch;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/FlightSegment.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightSegment.java
@@ -1,0 +1,94 @@
+package com.github.airmoment.flight.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "flight_segment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FlightSegment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer segmentOrder;
+
+	@Column(nullable = false, length = 10)
+	private String departureAirportCode;
+
+	@Column(nullable = false)
+	private String departureAirportName;
+
+	@Column(nullable = false)
+	private LocalDateTime departureTime;
+
+	@Column(nullable = false, length = 10)
+	private String arrivalAirportCode;
+
+	@Column(nullable = false)
+	private String arrivalAirportName;
+
+	@Column(nullable = false)
+	private LocalDateTime arrivalTime;
+
+	@Column(nullable = false)
+	private Integer duration;
+
+	@Column(nullable = false)
+	private String airline;
+
+	@Column(nullable = false)
+	private String flightNumber;
+
+	@Column(nullable = false)
+	private String travelClass;
+
+	@Column(nullable = true)
+	private String legroom;
+
+	@Column(nullable = true)
+	private String airplane;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "flight_offer_id", nullable = false)
+	private FlightOffer flightOffer;
+
+	public static FlightSegment of(FlightOffer flightOffer, Integer segmentOrder,
+		String departureAirportCode, String departureAirportName,
+		LocalDateTime departureTime, String arrivalAirportCode,
+		String arrivalAirportName, LocalDateTime arrivalTime,
+		Integer duration, String airline, String flightNumber,
+		String travelClass, String legroom, String airplane) {
+		FlightSegment segment = new FlightSegment();
+		segment.flightOffer = flightOffer;
+		segment.segmentOrder = segmentOrder;
+		segment.departureAirportCode = departureAirportCode;
+		segment.departureAirportName = departureAirportName;
+		segment.departureTime = departureTime;
+		segment.arrivalAirportCode = arrivalAirportCode;
+		segment.arrivalAirportName = arrivalAirportName;
+		segment.arrivalTime = arrivalTime;
+		segment.duration = duration;
+		segment.airline = airline;
+		segment.flightNumber = flightNumber;
+		segment.travelClass = travelClass;
+		segment.legroom = legroom;
+		segment.airplane = airplane;
+		return segment;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/FlightSegment.java
+++ b/src/main/java/com/github/airmoment/flight/domain/FlightSegment.java
@@ -49,13 +49,13 @@ public class FlightSegment {
 	@Column(nullable = false)
 	private Integer duration;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private String airline;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private String flightNumber;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private String travelClass;
 
 	@Column(nullable = true)

--- a/src/main/java/com/github/airmoment/flight/domain/enums/FlightDirection.java
+++ b/src/main/java/com/github/airmoment/flight/domain/enums/FlightDirection.java
@@ -1,0 +1,6 @@
+package com.github.airmoment.flight.domain.enums;
+
+public enum FlightDirection {
+	OUTBOUND,
+	INBOUND
+}

--- a/src/main/java/com/github/airmoment/flight/presentation/FlightController.java
+++ b/src/main/java/com/github/airmoment/flight/presentation/FlightController.java
@@ -1,0 +1,26 @@
+package com.github.airmoment.flight.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.airmoment.flight.scheduler.FlightDataScheduler;
+import com.github.airmoment.global.response.dto.SuccessResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/flights")
+@RequiredArgsConstructor
+public class FlightController {
+
+	private final FlightDataScheduler flightDataScheduler;
+
+	@PostMapping("/runScheduler")
+	public ResponseEntity<SuccessResponse<Void>> runScheduler(){
+		flightDataScheduler.collectFlightData();
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(200, "항공권 데이터가 조회 및 저장되었습니다."));
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightLayoverRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightLayoverRepository.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.airmoment.flight.domain.FlightLayover;
+
+@Repository
+public interface FlightLayoverRepository extends JpaRepository<FlightLayover, Long> {
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightOfferRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightOfferRepository.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.airmoment.flight.domain.FlightOffer;
+
+@Repository
+public interface FlightOfferRepository extends JpaRepository<FlightOffer, Long> {
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightPriceHistoryRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightPriceHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.airmoment.flight.domain.FlightPriceHistory;
+
+@Repository
+public interface FlightPriceHistoryRepository extends JpaRepository<FlightPriceHistory, Long> {
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightPriceInsightRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightPriceInsightRepository.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.airmoment.flight.domain.FlightPriceInsight;
+
+@Repository
+public interface FlightPriceInsightRepository extends JpaRepository<FlightPriceInsight, Long> {
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightSearchRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightSearchRepository.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.airmoment.flight.domain.FlightSearch;
+
+@Repository
+public interface FlightSearchRepository extends JpaRepository<FlightSearch, Long> {
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightSegmentRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightSegmentRepository.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.airmoment.flight.domain.FlightSegment;
+
+@Repository
+public interface FlightSegmentRepository extends JpaRepository<FlightSegment, Long> {
+}

--- a/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
+++ b/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
@@ -1,0 +1,84 @@
+package com.github.airmoment.flight.scheduler;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.github.airmoment.flight.domain.FlightOffer;
+import com.github.airmoment.flight.domain.FlightSearch;
+import com.github.airmoment.flight.service.FlightDataService;
+import com.github.airmoment.global.client.serpapi.SerpApiClient;
+import com.github.airmoment.global.client.serpapi.dto.FlightOfferDto;
+import com.github.airmoment.global.client.serpapi.dto.FlightSearchResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FlightDataScheduler {
+
+	private final SerpApiClient serpApiClient;
+	private final FlightDataService flightDataService;
+
+	private static final String ORIGIN = "ICN";
+	private static final List<String> TARGET_AIRPORTS = List.of("NRT", "DAD", "CDG");
+
+	@Scheduled(cron = "0 0 0,12 * * *")  // 매일 00시, 12시
+	public void collectFlightData() {
+		log.info("항공편 데이터 수집 시작: {}", LocalDateTime.now());
+
+		try {
+			LocalDate dynamicDeparture = LocalDate.now().plusMonths(1);
+			LocalDate dynamicReturn = dynamicDeparture.plusDays(6);
+			collectForPeriod(dynamicDeparture, dynamicReturn);
+
+			collectForPeriod(LocalDate.of(2026, 7, 13), LocalDate.of(2026, 7, 19));
+
+			log.info("항공편 데이터 수집 완료");
+		} catch (Exception e) {
+			log.error("항공편 데이터 수집 실패: {}", e.getMessage());
+		}
+	}
+
+	private void collectForPeriod(LocalDate departureDate, LocalDate returnDate) {
+		for (String targetAirport : TARGET_AIRPORTS) {
+			FlightSearch outboundFlightSearch = flightDataService.saveFlightSearch(ORIGIN, targetAirport, departureDate, returnDate, null);
+			FlightSearchResponse outboundResponse = serpApiClient.fetchOutBoundFlights(
+				ORIGIN, targetAirport,
+				departureDate.toString(),
+				returnDate.toString()
+			);
+			log.info("outboundResponse: {}", outboundResponse);
+			flightDataService.saveFlights(outboundFlightSearch, outboundResponse);
+
+			List<String> departureTokens = extractTop3DepartureTokens(outboundResponse);
+			for (String departureToken : departureTokens) {
+				FlightSearch inboundFlightSearch = flightDataService.saveFlightSearch(ORIGIN, targetAirport, departureDate, returnDate, departureToken);
+				FlightSearchResponse inboundResponse = serpApiClient.fetchInBoundFlights(
+					departureToken,
+					ORIGIN, targetAirport,
+					departureDate.toString(),
+					returnDate.toString()
+				);
+				log.info("inResponse: {}", inboundResponse);
+				flightDataService.saveFlights(inboundFlightSearch, inboundResponse);
+			}
+		}
+	}
+
+	private List<String> extractTop3DepartureTokens(FlightSearchResponse response) {
+		List<FlightOfferDto> flights = response.bestFlights() == null ? response.otherFlights() : response.bestFlights();
+
+		return flights
+			.stream()
+			.limit(3)
+			.map(FlightOfferDto::departureToken)
+			.filter(token -> token != null && !token.isBlank())
+			.toList();
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
+++ b/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import com.github.airmoment.flight.domain.FlightOffer;
 import com.github.airmoment.flight.domain.FlightSearch;
 import com.github.airmoment.flight.service.FlightDataService;
 import com.github.airmoment.global.client.serpapi.SerpApiClient;

--- a/src/main/java/com/github/airmoment/flight/service/FlightDataService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightDataService.java
@@ -1,0 +1,195 @@
+package com.github.airmoment.flight.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.github.airmoment.flight.domain.FlightLayover;
+import com.github.airmoment.flight.domain.FlightOffer;
+import com.github.airmoment.flight.domain.FlightPriceHistory;
+import com.github.airmoment.flight.domain.FlightPriceInsight;
+import com.github.airmoment.flight.domain.FlightSearch;
+import com.github.airmoment.flight.domain.FlightSegment;
+import com.github.airmoment.flight.domain.enums.FlightDirection;
+import com.github.airmoment.flight.repository.FlightLayoverRepository;
+import com.github.airmoment.flight.repository.FlightOfferRepository;
+import com.github.airmoment.flight.repository.FlightPriceHistoryRepository;
+import com.github.airmoment.flight.repository.FlightPriceInsightRepository;
+import com.github.airmoment.flight.repository.FlightSearchRepository;
+import com.github.airmoment.flight.repository.FlightSegmentRepository;
+import com.github.airmoment.global.client.serpapi.dto.FlightOfferDto;
+import com.github.airmoment.global.client.serpapi.dto.FlightSearchResponse;
+import com.github.airmoment.global.client.serpapi.dto.FlightSegmentDto;
+import com.github.airmoment.global.client.serpapi.dto.LayoverDto;
+import com.github.airmoment.global.client.serpapi.dto.PriceInsightDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FlightDataService {
+
+	private final FlightSearchRepository flightSearchRepository;
+	private final FlightOfferRepository flightOfferRepository;
+	private final FlightLayoverRepository flightLayoverRepository;
+	private final FlightPriceHistoryRepository flightPriceHistoryRepository;
+	private final FlightPriceInsightRepository flightPriceInsightRepository;
+	private final FlightSegmentRepository flightSegmentRepository;
+
+	public FlightSearch saveFlightSearch(String departureAirportCode, String arrivalAirportCode, LocalDate departureDate, LocalDate arrivalDate, String departureToken) {
+		FlightSearch flightSearch = FlightSearch.of(
+			departureAirportCode,
+			arrivalAirportCode,
+			departureDate,
+			arrivalDate,
+			departureToken
+		);
+
+		return flightSearchRepository.save(flightSearch);
+	}
+
+	public void saveFlights(FlightSearch flightSearch, FlightSearchResponse response) {
+		// FlightOffer, FlightSegment, FlightLayover 저장
+		saveFlightOffers(flightSearch, response.bestFlights(), true);
+		saveFlightOffers(flightSearch, response.otherFlights(), false);
+
+		// PriceInsight 저장
+		if (response.priceInsights() != null) {
+			savePriceInsight(flightSearch, response.priceInsights());
+		}
+	}
+
+	private void saveFlightOffers(FlightSearch flightSearch,
+		List<FlightOfferDto> offerDtos, boolean isBest) {
+		if (offerDtos == null || offerDtos.isEmpty()) return;
+
+		// departure_token 유무로 direction 판단
+		// inbound 2차 호출 응답은 departure_token이 없음
+		boolean isInbound = flightSearch.getDepartureToken() != null;
+		FlightDirection direction = isInbound ? FlightDirection.INBOUND : FlightDirection.OUTBOUND;
+
+		for (FlightOfferDto offerDto : offerDtos) {
+
+			// price가 null이면 저장 의미 없으므로 skip
+			if (offerDto.price() == null) {
+				log.warn("price가 null인 항공편 skip - flightNumber: {}",
+					offerDto.flights() != null && !offerDto.flights().isEmpty()
+						? offerDto.flights().get(0).flightNumber()
+						: "unknown");
+				continue;
+			}
+
+			// FlightOffer 저장
+			boolean hasLayover = offerDto.layovers() != null && !offerDto.layovers().isEmpty();
+			int layoverCount = hasLayover ? offerDto.layovers().size() : 0;
+
+			FlightOffer flightOffer = FlightOffer.of(
+				flightSearch,
+				offerDto.price(),
+				offerDto.totalDuration(),
+				hasLayover,
+				layoverCount,
+				isBest,
+				direction
+			);
+			flightOfferRepository.save(flightOffer);
+
+			// FlightSegment 저장
+			saveFlightSegments(flightOffer, offerDto.flights());
+
+			// FlightLayover 저장
+			if (hasLayover) {
+				saveFlightLayovers(flightOffer, offerDto.layovers());
+			}
+		}
+	}
+
+	private void saveFlightSegments(FlightOffer flightOffer, List<FlightSegmentDto> segmentDtos) {
+		if (segmentDtos == null || segmentDtos.isEmpty()) return;
+
+		for (int i = 0; i < segmentDtos.size(); i++) {
+			FlightSegmentDto dto = segmentDtos.get(i);
+
+			FlightSegment segment = FlightSegment.of(
+				flightOffer,
+				i + 1,  // segment_order (1부터 시작)
+				dto.departureAirport().id(),
+				dto.departureAirport().name(),
+				parseDateTime(dto.departureAirport().time()),
+				dto.arrivalAirport().id(),
+				dto.arrivalAirport().name(),
+				parseDateTime(dto.arrivalAirport().time()),
+				dto.duration(),
+				dto.airline(),
+				dto.flightNumber(),
+				dto.travelClass(),
+				dto.legroom(),
+				dto.airplane()
+			);
+			flightSegmentRepository.save(segment);
+		}
+	}
+
+	private void saveFlightLayovers(FlightOffer flightOffer, List<LayoverDto> layoverDtos) {
+		for (int i = 0; i < layoverDtos.size(); i++) {
+			LayoverDto dto = layoverDtos.get(i);
+
+			FlightLayover layover = FlightLayover.of(
+				flightOffer,
+				i + 1,  // layover_order (1부터 시작)
+				dto.id(),
+				dto.name(),
+				dto.duration(),
+				dto.overnight() != null && dto.overnight()
+			);
+			flightLayoverRepository.save(layover);
+		}
+	}
+
+	private void savePriceInsight(FlightSearch flightSearch, PriceInsightDto dto) {
+		// typical_price_range는 [min, max] 배열
+		Integer typicalPriceMin = null;
+		Integer typicalPriceMax = null;
+		if (dto.typicalPriceRange() != null && dto.typicalPriceRange().size() == 2) {
+			typicalPriceMin = dto.typicalPriceRange().get(0);
+			typicalPriceMax = dto.typicalPriceRange().get(1);
+		}
+
+		FlightPriceInsight insight = FlightPriceInsight.of(
+			flightSearch,
+			dto.lowestPrice(),
+			dto.priceLevel(),
+			typicalPriceMin,
+			typicalPriceMax
+		);
+		flightPriceInsightRepository.save(insight);
+
+		// price_history 저장
+		if (dto.priceHistory() != null) {
+			savePriceHistories(flightSearch, dto.priceHistory());
+		}
+	}
+
+	private void savePriceHistories(FlightSearch flightSearch, List<List<Long>> priceHistory) {
+		for (List<Long> entry : priceHistory) {
+			if (entry == null || entry.size() < 2) continue;
+
+			FlightPriceHistory history = FlightPriceHistory.of(
+				flightSearch,
+				entry.get(0),           // timestamp
+				entry.get(1).intValue() // price
+			);
+			flightPriceHistoryRepository.save(history);
+		}
+	}
+
+	private LocalDateTime parseDateTime(String dateTimeStr) {
+		if (dateTimeStr == null || dateTimeStr.isBlank()) return null;
+		return LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+	}
+}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiClient.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiClient.java
@@ -1,0 +1,60 @@
+package com.github.airmoment.global.client.serpapi;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.github.airmoment.global.client.serpapi.dto.FlightSearchResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SerpApiClient {
+
+	private final RestClient restClient;
+	private final SerpApiProperties properties;
+
+	public FlightSearchResponse fetchOutBoundFlights(String departureId, String arrivalId,
+		String outboundDate, String returnDate) {
+		return restClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.scheme("https")
+				.host("serpapi.com")
+				.path("/search")
+				.queryParam("engine", "google_flights")
+				.queryParam("api_key", properties.apiKey())
+				.queryParam("departure_id", departureId)
+				.queryParam("arrival_id", arrivalId)
+				.queryParam("outbound_date", outboundDate)
+				.queryParam("return_date", returnDate)
+				.queryParam("type", "1")       // 왕복
+				.queryParam("currency", "KRW")
+				.queryParam("hl", "ko")
+				.queryParam("gl", "kr")
+				.build())
+			.retrieve()
+			.body(FlightSearchResponse.class);
+	}
+
+	public FlightSearchResponse fetchInBoundFlights(String departureToken, String departureId,
+		String arrivalId, String outboundDate, String returnDate) {
+		return restClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.scheme("https")
+				.host("serpapi.com")
+				.path("/search")
+				.queryParam("departure_token", departureToken)
+				.queryParam("engine", "google_flights")
+				.queryParam("api_key", properties.apiKey())
+				.queryParam("departure_id", departureId)
+				.queryParam("arrival_id", arrivalId)
+				.queryParam("outbound_date", outboundDate)
+				.queryParam("return_date", returnDate)
+				.queryParam("currency", "KRW")
+				.queryParam("hl", "ko")
+				.queryParam("gl", "kr")
+				.build())
+			.retrieve()
+			.body(FlightSearchResponse.class);
+	}
+}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiProperties.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiProperties.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.global.client.serpapi;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "serpapi")
+public record SerpApiProperties(
+	String apiKey,
+	String baseUrl
+) {
+}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/dto/AirportDto.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/dto/AirportDto.java
@@ -1,0 +1,11 @@
+package com.github.airmoment.global.client.serpapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AirportDto(
+	@JsonProperty("name") String name,
+	@JsonProperty("id") String id,
+	@JsonProperty("time") String time
+) {}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/dto/FlightOfferDto.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/dto/FlightOfferDto.java
@@ -1,0 +1,16 @@
+package com.github.airmoment.global.client.serpapi.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FlightOfferDto(
+	@JsonProperty("flights") List<FlightSegmentDto> flights,
+	@JsonProperty("layovers") List<LayoverDto> layovers,
+	@JsonProperty("total_duration") Integer totalDuration,
+	@JsonProperty("price") Integer price,
+	@JsonProperty("type") String type,
+	@JsonProperty("departure_token") String departureToken
+) {}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/dto/FlightSearchResponse.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/dto/FlightSearchResponse.java
@@ -1,0 +1,13 @@
+package com.github.airmoment.global.client.serpapi.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FlightSearchResponse(
+	@JsonProperty("best_flights") List<FlightOfferDto> bestFlights,
+	@JsonProperty("other_flights") List<FlightOfferDto> otherFlights,
+	@JsonProperty("price_insights") PriceInsightDto priceInsights
+) {}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/dto/FlightSegmentDto.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/dto/FlightSegmentDto.java
@@ -1,0 +1,16 @@
+package com.github.airmoment.global.client.serpapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FlightSegmentDto(
+	@JsonProperty("departure_airport") AirportDto departureAirport,
+	@JsonProperty("arrival_airport") AirportDto arrivalAirport,
+	@JsonProperty("duration") Integer duration,
+	@JsonProperty("airline") String airline,
+	@JsonProperty("flight_number") String flightNumber,
+	@JsonProperty("travel_class") String travelClass,
+	@JsonProperty("legroom") String legroom,
+	@JsonProperty("airplane") String airplane
+) {}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/dto/LayoverDto.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/dto/LayoverDto.java
@@ -1,0 +1,12 @@
+package com.github.airmoment.global.client.serpapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LayoverDto(
+	@JsonProperty("name") String name,
+	@JsonProperty("id") String id,
+	@JsonProperty("duration") Integer duration,
+	@JsonProperty("overnight") Boolean overnight
+) {}

--- a/src/main/java/com/github/airmoment/global/client/serpapi/dto/PriceInsightDto.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/dto/PriceInsightDto.java
@@ -1,0 +1,14 @@
+package com.github.airmoment.global.client.serpapi.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PriceInsightDto(
+	@JsonProperty("lowest_price") Integer lowestPrice,
+	@JsonProperty("price_level") String priceLevel,
+	@JsonProperty("typical_price_range") List<Integer> typicalPriceRange,
+	@JsonProperty("price_history") List<List<Long>> priceHistory
+) {}

--- a/src/main/java/com/github/airmoment/global/config/WebConfig.java
+++ b/src/main/java/com/github/airmoment/global/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.github.airmoment.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -9,6 +11,11 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	@Bean
+	public RestClient restClient() {
+		return RestClient.create();
+	}
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/github/airmoment/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/airmoment/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.github.airmoment.global.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingRequestHeaderException;

--- a/src/main/java/com/github/airmoment/global/response/dto/SuccessResponse.java
+++ b/src/main/java/com/github/airmoment/global/response/dto/SuccessResponse.java
@@ -1,8 +1,5 @@
 package com.github.airmoment.global.response.dto;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-
 import com.github.airmoment.global.response.base.BaseCode;
 
 public record SuccessResponse<T>(

--- a/src/main/java/com/github/airmoment/global/response/dto/SuccessResponse.java
+++ b/src/main/java/com/github/airmoment/global/response/dto/SuccessResponse.java
@@ -1,5 +1,8 @@
 package com.github.airmoment.global.response.dto;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
 import com.github.airmoment.global.response.base.BaseCode;
 
 public record SuccessResponse<T>(
@@ -23,5 +26,9 @@ public record SuccessResponse<T>(
 	public static <T> SuccessResponse<T> of(BaseCode basecode, String message,
 		T data) { //반환 데이터 있음, 메시지 커스텀
 		return new SuccessResponse<>(basecode.getHttpStatus().value(), message, data);
+	}
+
+	public static <T> SuccessResponse<T> of(int httpStatusCode, String message) {
+		return new SuccessResponse<>(httpStatusCode, message, null);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #1

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 0시, 12시에 3개의 노선, 2개의 기간에 대해 스케쥴러를 호출하여 응답을 파싱해 각 엔티티에 나눠 저장합니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 항공권 데이터 검색·저장 기능 추가
  * 항공권 가격 인사이트 및 이력 저장 지원 추가
  * 정기 항공권 데이터 수집 스케줄러 추가 (주기적 수집)
  * 항공권 데이터 조회용 API 엔드포인트 추가

* **개선 사항**
  * 외부 API 클라이언트 및 DTO 기반 응답 처리 추가
  * 설정 속성 바인딩 및 HTTP 클라이언트 등록 개선
  * 성공 응답 생성 유연성 향상 (오버로드된 팩토리 메서드)
  * Git에서 특정 설정 파일 무시 규칙 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->