### PR TITLE
[feat] #24 - 항공권 조회 API 구현, FastAPI 서버와 연동하여 AI모델 예측 결과를 fetch

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -82,9 +82,9 @@ jobs:
             git reset --hard origin/develop
 
             if [ -d "/home/ubuntu/airmoment-ai-server" ]; then
-              cd /home/ubuntu/airmoment-ai-server && git fetch origin main && git reset --hard origin/main
+              cd /home/ubuntu/airmoment-ai-server && git fetch origin develop && git reset --hard origin/develop
             else
-              git clone https://github.com/airmoment/airmoment-ai-server.git /home/ubuntu/airmoment-ai-server
+              git clone -b develop https://github.com/airmoment/airmoment-ai-server.git /home/ubuntu/airmoment-ai-server
             fi
 
             aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -80,6 +80,16 @@ jobs:
             cd /home/ubuntu/airmoment-server
             git fetch origin develop
             git reset --hard origin/develop
+
+            if [ -d "/home/ubuntu/airmoment-ai-server" ]; then
+              cd /home/ubuntu/airmoment-ai-server && git fetch origin main && git reset --hard origin/main
+            else
+              git clone https://github.com/airmoment/airmoment-ai-server.git /home/ubuntu/airmoment-ai-server
+            fi
+
+            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+              docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+            cd /home/ubuntu/airmoment-server
             docker pull ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
             docker-compose -f docker-compose-dev.yml down
-            docker-compose -f docker-compose-dev.yml up -d
+            docker-compose -f docker-compose-dev.yml up -d --build fastapi

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -92,4 +92,4 @@ jobs:
             cd /home/ubuntu/airmoment-server
             docker pull ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
             docker-compose -f docker-compose-dev.yml down
-            docker-compose -f docker-compose-dev.yml up -d --build fastapi
+            docker-compose -f docker-compose-dev.yml up -d --build

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,6 +10,14 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_started
+    restart: always
+
+  fastapi:
+    build: ../airmoment-ai-server
+    ports:
+      - "8000:8000"
     restart: always
 
   db:
@@ -28,6 +36,12 @@ services:
       timeout: 5s
       retries: 10
       start_period: 40s
+    restart: always
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
     restart: always
 
 volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,14 +16,14 @@ services:
 
   fastapi:
     build: ../airmoment-ai-server
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     restart: always
 
   db:
     image: mysql:8.0
-    ports:
-      - "3306:3306"
+    expose:
+      - "6379"
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: airmoment

--- a/src/main/java/com/github/airmoment/AirmomentApplication.java
+++ b/src/main/java/com/github/airmoment/AirmomentApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import com.github.airmoment.global.client.discord.DiscordProperties;
+import com.github.airmoment.global.client.fastapi.AIServerProperties;
 import com.github.airmoment.global.client.google.GoogleSheetsProperties;
 import com.github.airmoment.global.client.serpapi.SerpApiProperties;
 
@@ -13,7 +14,8 @@ import com.github.airmoment.global.client.serpapi.SerpApiProperties;
 @EnableConfigurationProperties({
 	SerpApiProperties.class,
 	DiscordProperties.class,
-	GoogleSheetsProperties.class
+	GoogleSheetsProperties.class,
+	AIServerProperties.class
 })
 @SpringBootApplication
 public class AirmomentApplication {

--- a/src/main/java/com/github/airmoment/exception/FlightErrorCode.java
+++ b/src/main/java/com/github/airmoment/exception/FlightErrorCode.java
@@ -1,0 +1,21 @@
+package com.github.airmoment.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.airmoment.global.response.base.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FlightErrorCode implements BaseCode {
+	/*
+	500 INTERNAL SERVER ERROR
+	 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예기치 않은 서버 에러가 발생하였습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/github/airmoment/flight/domain/Airline.java
+++ b/src/main/java/com/github/airmoment/flight/domain/Airline.java
@@ -1,0 +1,38 @@
+package com.github.airmoment.flight.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "airline")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Airline {
+
+	private static final String DEFAULT_PHOTO =
+		"https://www.logoyogo.com/web/wp-content/uploads/edd/2021/03/logoyogo-1-164.jpg";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String name;
+
+	@Column(nullable = false)
+	private String photo;
+
+	public static Airline of(String name) {
+		Airline airline = new Airline();
+		airline.name = name;
+		airline.photo = DEFAULT_PHOTO;
+		return airline;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/domain/enums/AirportCode.java
+++ b/src/main/java/com/github/airmoment/flight/domain/enums/AirportCode.java
@@ -1,0 +1,15 @@
+package com.github.airmoment.flight.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AirportCode {
+	ICN("ICN"),
+	CDG("CDG"),
+	JFK("JFK"),
+	SYD("SYD");
+
+	private final String code;
+}

--- a/src/main/java/com/github/airmoment/flight/domain/enums/AirportRoute.java
+++ b/src/main/java/com/github/airmoment/flight/domain/enums/AirportRoute.java
@@ -1,0 +1,15 @@
+package com.github.airmoment.flight.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AirportRoute {
+	ICN_TO_CDG(AirportCode.ICN, AirportCode.CDG),
+	ICN_TO_JFK(AirportCode.ICN, AirportCode.JFK),
+	ICN_TO_SYD(AirportCode.ICN, AirportCode.SYD);
+
+	private final AirportCode departure;
+	private final AirportCode arrival;
+}

--- a/src/main/java/com/github/airmoment/flight/domain/enums/FlightSortOption.java
+++ b/src/main/java/com/github/airmoment/flight/domain/enums/FlightSortOption.java
@@ -1,0 +1,7 @@
+package com.github.airmoment.flight.domain.enums;
+
+public enum FlightSortOption {
+	DEPARTURE_TIME_ASC,
+	DEPARTURE_TIME_DESC,
+	PRICE_ASC
+}

--- a/src/main/java/com/github/airmoment/flight/dto/AIPredictionResponse.java
+++ b/src/main/java/com/github/airmoment/flight/dto/AIPredictionResponse.java
@@ -1,0 +1,6 @@
+package com.github.airmoment.flight.dto;
+
+public record AIPredictionResponse(
+	String decision
+) {
+}

--- a/src/main/java/com/github/airmoment/flight/dto/CachedFlightItem.java
+++ b/src/main/java/com/github/airmoment/flight/dto/CachedFlightItem.java
@@ -1,0 +1,14 @@
+package com.github.airmoment.flight.dto;
+
+import java.time.LocalTime;
+
+public record CachedFlightItem(
+	String airlineName,
+	String airlinePhoto,
+	LocalTime departureTime,
+	LocalTime arrivalTime,
+	int duration,
+	int price,
+	boolean nonstop
+) {
+}

--- a/src/main/java/com/github/airmoment/flight/dto/CachedFlightResult.java
+++ b/src/main/java/com/github/airmoment/flight/dto/CachedFlightResult.java
@@ -1,0 +1,10 @@
+package com.github.airmoment.flight.dto;
+
+import java.util.List;
+
+public record CachedFlightResult(
+	List<CachedFlightItem> flights,
+	Integer typicalPriceMin,
+	Integer typicalPriceMax
+) {
+}

--- a/src/main/java/com/github/airmoment/flight/dto/FlightFeatureVector.java
+++ b/src/main/java/com/github/airmoment/flight/dto/FlightFeatureVector.java
@@ -1,0 +1,23 @@
+package com.github.airmoment.flight.dto;
+
+public record FlightFeatureVector(
+	String routeId,
+	String searchedDayOfWeek,
+	int daysToDeparture,
+	boolean isWeekendSearch,
+	boolean isLongHaul,
+	int offerCount,
+	float nonstopRatio,
+	Integer cheapestNonstopPrice,
+	boolean cheapestOfferHasLayover,
+	int currentCheapestPrice,
+	Integer currGapToTypicalMin,
+	Integer currGapToTypicalMax,
+	Float histRecentStd,
+	Float histRecentSlope,
+	Float currVsHistMean,
+	Float priceChange1,
+	Float rollingStd3,
+	Float priceVsRollingMean3
+) {
+}

--- a/src/main/java/com/github/airmoment/flight/dto/FlightFeatureVector.java
+++ b/src/main/java/com/github/airmoment/flight/dto/FlightFeatureVector.java
@@ -1,15 +1,35 @@
 package com.github.airmoment.flight.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record FlightFeatureVector(
+	@NotNull
 	String routeId,
+	@NotNull
+	String departureAirportCode,
+	@NotNull
+	String arrivalAirportCode,
+	String outboundDate,
+	@NotNull
 	String searchedDayOfWeek,
+	@NotNull
 	int daysToDeparture,
+	@NotNull
 	boolean isWeekendSearch,
+	@NotNull
 	boolean isLongHaul,
+	@NotNull
 	int offerCount,
+	@NotNull
 	float nonstopRatio,
 	Integer cheapestNonstopPrice,
+	@NotNull
 	boolean cheapestOfferHasLayover,
+	@NotNull
 	int currentCheapestPrice,
 	Integer currGapToTypicalMin,
 	Integer currGapToTypicalMax,

--- a/src/main/java/com/github/airmoment/flight/dto/FlightItemResponse.java
+++ b/src/main/java/com/github/airmoment/flight/dto/FlightItemResponse.java
@@ -1,0 +1,23 @@
+package com.github.airmoment.flight.dto;
+
+import java.time.LocalTime;
+
+public record FlightItemResponse(
+	String airlineName,
+	String airlinePhoto,
+	LocalTime departureTime,
+	LocalTime arrivalTime,
+	int duration,
+	int price
+) {
+	public static FlightItemResponse from(CachedFlightItem item) {
+		return new FlightItemResponse(
+			item.airlineName(),
+			item.airlinePhoto(),
+			item.departureTime(),
+			item.arrivalTime(),
+			item.duration(),
+			item.price()
+		);
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/dto/FlightListResponse.java
+++ b/src/main/java/com/github/airmoment/flight/dto/FlightListResponse.java
@@ -1,0 +1,12 @@
+package com.github.airmoment.flight.dto;
+
+import java.util.List;
+
+public record FlightListResponse(
+	int totalCount,
+	List<FlightItemResponse> flightList
+) {
+	public static FlightListResponse of(List<FlightItemResponse> items) {
+		return new FlightListResponse(items.size(), items);
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/dto/FlightListResponse.java
+++ b/src/main/java/com/github/airmoment/flight/dto/FlightListResponse.java
@@ -3,10 +3,11 @@ package com.github.airmoment.flight.dto;
 import java.util.List;
 
 public record FlightListResponse(
+	FlightPredictDto predict,
 	int totalCount,
 	List<FlightItemResponse> flightList
 ) {
-	public static FlightListResponse of(List<FlightItemResponse> items) {
-		return new FlightListResponse(items.size(), items);
+	public static FlightListResponse of(FlightPredictDto predict, List<FlightItemResponse> items) {
+		return new FlightListResponse(predict, items.size(), items);
 	}
 }

--- a/src/main/java/com/github/airmoment/flight/dto/FlightPredictDto.java
+++ b/src/main/java/com/github/airmoment/flight/dto/FlightPredictDto.java
@@ -1,0 +1,6 @@
+package com.github.airmoment.flight.dto;
+
+public record FlightPredictDto(
+	String decision
+) {
+}

--- a/src/main/java/com/github/airmoment/flight/presentation/FlightController.java
+++ b/src/main/java/com/github/airmoment/flight/presentation/FlightController.java
@@ -1,12 +1,20 @@
 package com.github.airmoment.flight.presentation;
 
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.airmoment.flight.domain.enums.FlightSortOption;
+import com.github.airmoment.flight.dto.FlightListResponse;
 import com.github.airmoment.flight.scheduler.FlightDataScheduler;
 import com.github.airmoment.flight.scheduler.FlightReportScheduler;
+import com.github.airmoment.flight.service.FlightSearchService;
 import com.github.airmoment.global.response.dto.SuccessResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +26,21 @@ public class FlightController {
 
 	private final FlightDataScheduler flightDataScheduler;
 	private final FlightReportScheduler flightReportScheduler;
+	private final FlightSearchService flightSearchService;
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<FlightListResponse>> searchFlights(
+		@RequestParam String departureCode,
+		@RequestParam String arrivalCode,
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate departureAt,
+		@RequestParam(required = false) FlightSortOption sort,
+		@RequestParam(required = false) Boolean nonstopOnly,
+		@RequestParam(required = false) Integer maxPrice
+	) {
+		FlightListResponse response = flightSearchService.searchFlights(
+			departureCode, arrivalCode, departureAt, sort, nonstopOnly, maxPrice);
+		return ResponseEntity.ok(new SuccessResponse<>(200, "항공권 조회 성공", response));
+	}
 
 	@PostMapping("/dataScheduler")
 	public ResponseEntity<SuccessResponse<Void>> runDataScheduler() {

--- a/src/main/java/com/github/airmoment/flight/repository/AirlineRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/AirlineRepository.java
@@ -1,0 +1,11 @@
+package com.github.airmoment.flight.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.airmoment.flight.domain.Airline;
+
+public interface AirlineRepository extends JpaRepository<Airline, Long> {
+	Optional<Airline> findByName(String name);
+}

--- a/src/main/java/com/github/airmoment/flight/repository/FlightOfferRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightOfferRepository.java
@@ -1,10 +1,35 @@
 package com.github.airmoment.flight.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.github.airmoment.flight.domain.FlightOffer;
+import com.github.airmoment.flight.domain.enums.FlightDirection;
 
 @Repository
 public interface FlightOfferRepository extends JpaRepository<FlightOffer, Long> {
+
+	@Query("SELECT MIN(fo.price) FROM FlightOffer fo "
+		+ "WHERE fo.flightSearch.departureAirportCode = :dep "
+		+ "AND fo.flightSearch.arrivalAirportCode = :arr "
+		+ "AND fo.flightSearch.outboundDate = :date "
+		+ "AND fo.direction = :direction "
+		+ "AND fo.flightSearch.searchedAt <= :now "
+		+ "GROUP BY fo.flightSearch.id "
+		+ "ORDER BY MAX(fo.flightSearch.searchedAt) DESC")
+	List<Integer> findRecentMinOutboundPrices(
+		@Param("dep") String dep,
+		@Param("arr") String arr,
+		@Param("date") LocalDate date,
+		@Param("direction") FlightDirection direction,
+		@Param("now") LocalDateTime now,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/github/airmoment/flight/repository/FlightPriceHistoryRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightPriceHistoryRepository.java
@@ -16,10 +16,17 @@ import com.github.airmoment.flight.domain.FlightPriceHistory;
 public interface FlightPriceHistoryRepository extends JpaRepository<FlightPriceHistory, Long> {
 
 	@Query("SELECT fph.price FROM FlightPriceHistory fph "
-		+ "WHERE fph.flightSearch.departureAirportCode = :dep "
-		+ "AND fph.flightSearch.arrivalAirportCode = :arr "
-		+ "AND fph.flightSearch.outboundDate = :date "
-		+ "AND fph.flightSearch.searchedAt <= :now "
+		+ "JOIN fph.flightSearch fs "
+		+ "WHERE fs.departureAirportCode = :dep "
+		+ "AND fs.arrivalAirportCode = :arr "
+		+ "AND fs.outboundDate = :date "
+		+ "AND fs.searchedAt = ("
+		+ "  SELECT MAX(fs2.searchedAt) FROM FlightSearch fs2 "
+		+ "  WHERE fs2.departureAirportCode = :dep "
+		+ "  AND fs2.arrivalAirportCode = :arr "
+		+ "  AND fs2.outboundDate = :date "
+		+ "  AND fs2.searchedAt <= :now"
+		+ ") "
 		+ "ORDER BY fph.timeStamp DESC")
 	List<Integer> findLatestHistoryPrices(
 		@Param("dep") String dep,

--- a/src/main/java/com/github/airmoment/flight/repository/FlightPriceHistoryRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightPriceHistoryRepository.java
@@ -1,10 +1,31 @@
 package com.github.airmoment.flight.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.github.airmoment.flight.domain.FlightPriceHistory;
 
 @Repository
 public interface FlightPriceHistoryRepository extends JpaRepository<FlightPriceHistory, Long> {
+
+	@Query("SELECT fph.price FROM FlightPriceHistory fph "
+		+ "WHERE fph.flightSearch.departureAirportCode = :dep "
+		+ "AND fph.flightSearch.arrivalAirportCode = :arr "
+		+ "AND fph.flightSearch.outboundDate = :date "
+		+ "AND fph.flightSearch.searchedAt <= :now "
+		+ "ORDER BY fph.timeStamp DESC")
+	List<Integer> findLatestHistoryPrices(
+		@Param("dep") String dep,
+		@Param("arr") String arr,
+		@Param("date") LocalDate date,
+		@Param("now") LocalDateTime now,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/github/airmoment/flight/repository/FlightPriceInsightRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightPriceInsightRepository.java
@@ -1,29 +1,10 @@
 package com.github.airmoment.flight.repository;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.github.airmoment.flight.domain.FlightPriceInsight;
 
 @Repository
 public interface FlightPriceInsightRepository extends JpaRepository<FlightPriceInsight, Long> {
-
-	@Query("SELECT fpi.lowestPrice FROM FlightPriceInsight fpi "
-		+ "WHERE fpi.flightSearch.departureAirportCode = :dep "
-		+ "AND fpi.flightSearch.arrivalAirportCode = :arr "
-		+ "AND fpi.flightSearch.outboundDate = :date "
-		+ "AND fpi.lowestPrice IS NOT NULL "
-		+ "ORDER BY fpi.flightSearch.searchedAt DESC")
-	List<Integer> findRecentLowestPrices(
-		@Param("dep") String dep,
-		@Param("arr") String arr,
-		@Param("date") LocalDate date,
-		Pageable pageable
-	);
 }

--- a/src/main/java/com/github/airmoment/flight/repository/FlightPriceInsightRepository.java
+++ b/src/main/java/com/github/airmoment/flight/repository/FlightPriceInsightRepository.java
@@ -1,10 +1,29 @@
 package com.github.airmoment.flight.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.github.airmoment.flight.domain.FlightPriceInsight;
 
 @Repository
 public interface FlightPriceInsightRepository extends JpaRepository<FlightPriceInsight, Long> {
+
+	@Query("SELECT fpi.lowestPrice FROM FlightPriceInsight fpi "
+		+ "WHERE fpi.flightSearch.departureAirportCode = :dep "
+		+ "AND fpi.flightSearch.arrivalAirportCode = :arr "
+		+ "AND fpi.flightSearch.outboundDate = :date "
+		+ "AND fpi.lowestPrice IS NOT NULL "
+		+ "ORDER BY fpi.flightSearch.searchedAt DESC")
+	List<Integer> findRecentLowestPrices(
+		@Param("dep") String dep,
+		@Param("arr") String arr,
+		@Param("date") LocalDate date,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
+++ b/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.github.airmoment.flight.domain.FlightSearch;
+import com.github.airmoment.flight.domain.enums.AirportRoute;
 import com.github.airmoment.flight.domain.enums.FlightDirection;
 import com.github.airmoment.flight.service.FlightDataService;
 import com.github.airmoment.global.client.serpapi.SerpApiClient;
@@ -25,8 +26,6 @@ public class FlightDataScheduler {
 	private final SerpApiClient serpApiClient;
 	private final FlightDataService flightDataService;
 
-	private static final String ORIGIN = "ICN";
-	private static final List<String> TARGET_AIRPORTS = List.of("CDG", "JFK", "SYD");
 	private static final List<LocalDate> FIXED_OUTBOUND_DATES = List.of(
 		LocalDate.of(2026, 7, 25),
 		LocalDate.of(2026, 11, 15),
@@ -52,22 +51,23 @@ public class FlightDataScheduler {
 	}
 
 	private void collectForPeriod(LocalDate dynamicOutboundDate) {
-		for (String targetAirport : TARGET_AIRPORTS) {
-			fetchAndSaveData(targetAirport, dynamicOutboundDate);
+		for (AirportRoute route : AirportRoute.values()) {
+			fetchAndSaveData(route, dynamicOutboundDate);
 			for (LocalDate outboundDate : FIXED_OUTBOUND_DATES) {
-				fetchAndSaveData(targetAirport, outboundDate);
+				fetchAndSaveData(route, outboundDate);
 			}
 		}
 	}
 
-	private void fetchAndSaveData(String targetAirport, LocalDate outboundDate) {
-		try{
-			FlightSearch outboundFlightSearch = flightDataService.saveFlightSearch(ORIGIN, targetAirport, outboundDate);
-			FlightSearchResponse outboundResponse = serpApiClient.fetchFlights(ORIGIN, targetAirport, outboundDate.toString());
+	private void fetchAndSaveData(AirportRoute route, LocalDate outboundDate) {
+		String departure = route.getDeparture().getCode();
+		String arrival = route.getArrival().getCode();
+		try {
+			FlightSearch outboundFlightSearch = flightDataService.saveFlightSearch(departure, arrival, outboundDate);
+			FlightSearchResponse outboundResponse = serpApiClient.fetchFlights(departure, arrival, outboundDate.toString());
 			flightDataService.saveFlights(outboundFlightSearch, outboundResponse, FlightDirection.OUTBOUND);
-			}
-			catch(Exception e) {
-			log.error("{}에 출발하는 {}행 항공편 데이터 수집이 실패하였습니다. ", outboundDate, targetAirport);
-			}
+		} catch (Exception e) {
+			log.error("{}에 출발하는 {}행 항공편 데이터 수집이 실패하였습니다. ", outboundDate, arrival);
+		}
 	}
 }

--- a/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
+++ b/src/main/java/com/github/airmoment/flight/scheduler/FlightDataScheduler.java
@@ -63,8 +63,8 @@ public class FlightDataScheduler {
 		String departure = route.getDeparture().getCode();
 		String arrival = route.getArrival().getCode();
 		try {
-			FlightSearch outboundFlightSearch = flightDataService.saveFlightSearch(departure, arrival, outboundDate);
 			FlightSearchResponse outboundResponse = serpApiClient.fetchFlights(departure, arrival, outboundDate.toString());
+			FlightSearch outboundFlightSearch = flightDataService.saveFlightSearch(departure, arrival, outboundDate);
 			flightDataService.saveFlights(outboundFlightSearch, outboundResponse, FlightDirection.OUTBOUND);
 		} catch (Exception e) {
 			log.error("{}에 출발하는 {}행 항공편 데이터 수집이 실패하였습니다. ", outboundDate, arrival);

--- a/src/main/java/com/github/airmoment/flight/service/AirlineService.java
+++ b/src/main/java/com/github/airmoment/flight/service/AirlineService.java
@@ -1,0 +1,26 @@
+package com.github.airmoment.flight.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.airmoment.flight.domain.Airline;
+import com.github.airmoment.flight.repository.AirlineRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AirlineService {
+
+	private final AirlineRepository airlineRepository;
+
+	@Transactional
+	public String findOrCreatePhoto(String airlineName) {
+		if (airlineName == null || airlineName.isBlank()) {
+			return null;
+		}
+		return airlineRepository.findByName(airlineName)
+			.orElseGet(() -> airlineRepository.save(Airline.of(airlineName)))
+			.getPhoto();
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/service/FlightFeatureService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightFeatureService.java
@@ -1,0 +1,144 @@
+package com.github.airmoment.flight.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.airmoment.flight.domain.enums.FlightDirection;
+import com.github.airmoment.flight.dto.CachedFlightItem;
+import com.github.airmoment.flight.dto.CachedFlightResult;
+import com.github.airmoment.flight.dto.FlightFeatureVector;
+import com.github.airmoment.flight.repository.FlightOfferRepository;
+import com.github.airmoment.flight.repository.FlightPriceHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FlightFeatureService {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final int ROLLING_WINDOW = 3;
+	private static final int HISTORY_WINDOW = 5;
+
+	// 장거리 노선 사전 정의 (편도 기준 6시간 이상)
+	private static final Set<String> LONG_HAUL_ROUTES = Set.of(
+		"ICN-CDG", "ICN-JFK", "ICN-SYD", "ICN-LAX", "ICN-LHR", "ICN-ORD",
+		"ICN-YVR", "ICN-SFO", "ICN-SEA", "ICN-ATL", "ICN-DFW", "ICN-YYZ",
+		"CDG-ICN", "JFK-ICN", "SYD-ICN", "LAX-ICN", "LHR-ICN", "ORD-ICN"
+	);
+
+	private final FlightOfferRepository flightOfferRepository;
+	private final FlightPriceHistoryRepository priceHistoryRepository;
+
+	public FlightFeatureVector calculate(
+		String departureCode,
+		String arrivalCode,
+		LocalDate departureAt,
+		CachedFlightResult cached
+	) {
+		LocalDateTime now = LocalDateTime.now(KST);
+		String routeId = departureCode + "-" + arrivalCode;
+		String searchedDayOfWeek = now.getDayOfWeek().name().substring(0, 3); // MON~SUN
+		int daysToDeparture = (int) ChronoUnit.DAYS.between(now.toLocalDate(), departureAt);
+		boolean isWeekendSearch = searchedDayOfWeek.equals("SAT") || searchedDayOfWeek.equals("SUN");
+		boolean isLongHaul = LONG_HAUL_ROUTES.contains(routeId);
+
+		// 2-2: 실시간 검색 결과에서 집계
+		List<CachedFlightItem> flights = cached.flights();
+		int offerCount = flights.size();
+
+		int currentCheapestPrice = flights.stream()
+			.mapToInt(CachedFlightItem::price)
+			.min()
+			.orElse(0);
+
+		long nonstopCount = flights.stream().filter(CachedFlightItem::nonstop).count();
+		float nonstopRatio = offerCount > 0 ? (float) nonstopCount / offerCount : 0f;
+
+		OptionalInt cheapestNonstopOpt = flights.stream()
+			.filter(CachedFlightItem::nonstop)
+			.mapToInt(CachedFlightItem::price)
+			.min();
+		Integer cheapestNonstopPrice = cheapestNonstopOpt.isPresent() ? cheapestNonstopOpt.getAsInt() : null;
+
+		boolean cheapestOfferHasLayover = flights.stream()
+			.min(Comparator.comparingInt(CachedFlightItem::price))
+			.map(item -> !item.nonstop())
+			.orElse(false);
+
+		Integer currGapToTypicalMin = cached.typicalPriceMin() != null
+			? currentCheapestPrice - cached.typicalPriceMin() : null;
+		Integer currGapToTypicalMax = cached.typicalPriceMax() != null
+			? currentCheapestPrice - cached.typicalPriceMax() : null;
+
+		// 2-3: trajectory 내 과거 FlightSearch별 최저 OUTBOUND 가격 시계열 (최근 3개, DESC)
+		List<Integer> recentObs = flightOfferRepository.findRecentMinOutboundPrices(
+			departureCode, arrivalCode, departureAt, FlightDirection.OUTBOUND,
+			now, PageRequest.of(0, ROLLING_WINDOW));
+
+		Float priceChange1 = !recentObs.isEmpty()
+			? (float) (currentCheapestPrice - recentObs.get(0)) : null;
+		Float rollingStd3 = recentObs.size() >= 2
+			? computeStd(recentObs) : null;
+		Float priceVsRollingMean3 = !recentObs.isEmpty()
+			? currentCheapestPrice - computeMean(recentObs) : null;
+
+		// 2-4: SerpAPI price_history (DB 저장값, 최근 N=5개, DESC → 역순으로 slope 계산)
+		List<Integer> histPricesDesc = priceHistoryRepository.findLatestHistoryPrices(
+			departureCode, arrivalCode, departureAt, now, PageRequest.of(0, HISTORY_WINDOW));
+		List<Integer> histPrices = new ArrayList<>(histPricesDesc);
+		Collections.reverse(histPrices);
+
+		Float histRecentStd = histPrices.size() >= 2 ? computeStd(histPrices) : null;
+		Float histRecentSlope = histPrices.size() >= 2 ? computeSlope(histPrices) : null;
+		Float currVsHistMean = !histPrices.isEmpty()
+			? currentCheapestPrice / computeMean(histPrices) : null;
+
+		return new FlightFeatureVector(
+			routeId, searchedDayOfWeek, daysToDeparture, isWeekendSearch, isLongHaul,
+			offerCount, nonstopRatio, cheapestNonstopPrice, cheapestOfferHasLayover, currentCheapestPrice,
+			currGapToTypicalMin, currGapToTypicalMax,
+			histRecentStd, histRecentSlope, currVsHistMean,
+			priceChange1, rollingStd3, priceVsRollingMean3
+		);
+	}
+
+	private float computeMean(List<Integer> values) {
+		return (float) values.stream().mapToInt(Integer::intValue).average().orElse(0);
+	}
+
+	private float computeStd(List<Integer> values) {
+		float mean = computeMean(values);
+		double variance = values.stream()
+			.mapToDouble(v -> Math.pow(v - mean, 2))
+			.average()
+			.orElse(0);
+		return (float) Math.sqrt(variance);
+	}
+
+	private float computeSlope(List<Integer> values) {
+		int n = values.size();
+		float sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+		for (int i = 0; i < n; i++) {
+			sumX += i;
+			sumY += values.get(i);
+			sumXY += (float) i * values.get(i);
+			sumX2 += (float) i * i;
+		}
+		float denom = n * sumX2 - sumX * sumX;
+		return denom == 0 ? 0f : (n * sumXY - sumX * sumY) / denom;
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/service/FlightFeatureService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightFeatureService.java
@@ -108,7 +108,7 @@ public class FlightFeatureService {
 			? currentCheapestPrice / computeMean(histPrices) : null;
 
 		return new FlightFeatureVector(
-			routeId, searchedDayOfWeek, daysToDeparture, isWeekendSearch, isLongHaul,
+			routeId, departureCode, arrivalCode, departureAt.toString(), searchedDayOfWeek, daysToDeparture, isWeekendSearch, isLongHaul,
 			offerCount, nonstopRatio, cheapestNonstopPrice, cheapestOfferHasLayover, currentCheapestPrice,
 			currGapToTypicalMin, currGapToTypicalMax,
 			histRecentStd, histRecentSlope, currVsHistMean,

--- a/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
@@ -11,12 +11,9 @@ import java.util.List;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.airmoment.exception.FlightErrorCode;
-import com.github.airmoment.flight.domain.Airline;
 import com.github.airmoment.flight.domain.enums.FlightSortOption;
 import com.github.airmoment.flight.dto.AIPredictionResponse;
 import com.github.airmoment.flight.dto.CachedFlightItem;
@@ -25,7 +22,6 @@ import com.github.airmoment.flight.dto.FlightFeatureVector;
 import com.github.airmoment.flight.dto.FlightItemResponse;
 import com.github.airmoment.flight.dto.FlightListResponse;
 import com.github.airmoment.flight.dto.FlightPredictDto;
-import com.github.airmoment.flight.repository.AirlineRepository;
 import com.github.airmoment.global.client.fastapi.AIServerClient;
 import com.github.airmoment.global.client.serpapi.SerpApiClient;
 import com.github.airmoment.global.client.serpapi.dto.FlightOfferDto;
@@ -46,13 +42,12 @@ public class FlightSearchService {
 	private static final DateTimeFormatter SEGMENT_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
 	private final SerpApiClient serpApiClient;
-	private final AirlineRepository airlineRepository;
+	private final AirlineService airlineService;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ObjectMapper objectMapper;
 	private final FlightFeatureService flightFeatureService;
 	private final AIServerClient aiServerClient;
 
-	@Transactional
 	public FlightListResponse searchFlights(
 		String departureCode,
 		String arrivalCode,
@@ -72,15 +67,28 @@ public class FlightSearchService {
 
 		FlightSortOption effectiveSort = sort != null ? sort : FlightSortOption.DEPARTURE_TIME_ASC;
 
-		List<FlightItemResponse> result = cached.flights().stream()
+		List<CachedFlightItem> filteredFlights = cached.flights().stream()
 			.filter(item -> nonstopOnly == null || !nonstopOnly || item.nonstop())
 			.filter(item -> maxPrice == null || item.price() <= maxPrice)
+			.toList();
+
+		List<FlightItemResponse> result = filteredFlights.stream()
 			.sorted(getComparator(effectiveSort))
 			.map(FlightItemResponse::from)
 			.toList();
 
+		if (result.isEmpty()) {
+			return FlightListResponse.of(null, null);
+		}
+
+		CachedFlightResult predictionInput = new CachedFlightResult(
+			filteredFlights,
+			cached.typicalPriceMin(),
+			cached.typicalPriceMax()
+		);
+
 		// 입력값, 항공권 조회값을 바탕으로 featureVector 계산
-		FlightFeatureVector featureVector = flightFeatureService.calculate(departureCode, arrivalCode, departureAt, cached);
+		FlightFeatureVector featureVector = flightFeatureService.calculate(departureCode, arrivalCode, departureAt, predictionInput);
 		log.info("입력한 조건의 항공권 결과에 대한 feature vector 계산이 완료되었습니다. \n****FeatureVector****\n {}", featureVector);
 
 		AIPredictionResponse prediction = null;
@@ -142,12 +150,7 @@ public class FlightSearchService {
 	}
 
 	private String resolveAirlinePhoto(String airlineName) {
-		if (airlineName == null || airlineName.isBlank()) {
-			return null;
-		}
-		return airlineRepository.findByName(airlineName)
-			.orElseGet(() -> airlineRepository.save(Airline.of(airlineName)))
-			.getPhoto();
+		return airlineService.findOrCreatePhoto(airlineName);
 	}
 
 	private LocalTime parseTime(String timeStr) {
@@ -167,12 +170,12 @@ public class FlightSearchService {
 	}
 
 	private CachedFlightResult getFromCache(String key) {
-		String json = redisTemplate.opsForValue().get(key);
-		if (json == null) return null;
 		try {
+			String json = redisTemplate.opsForValue().get(key);
+			if (json == null) return null;
 			return objectMapper.readValue(json, CachedFlightResult.class);
-		} catch (JsonProcessingException e) {
-			log.warn("Redis 캐시 역직렬화 실패 - key: {}, error: {}", key, e.getMessage());
+		} catch (Exception e) {
+			log.warn("Redis 캐시 조회 실패 - key: {}, error: {}", key, e.getMessage());
 			return null;
 		}
 	}
@@ -180,7 +183,7 @@ public class FlightSearchService {
 	private void saveToCache(String key, CachedFlightResult result) {
 		try {
 			redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(result), CACHE_TTL);
-		} catch (JsonProcessingException e) {
+		} catch (Exception e) {
 			log.warn("Redis 캐시 저장 실패 - key: {}, error: {}", key, e.getMessage());
 		}
 	}

--- a/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
@@ -19,6 +19,7 @@ import com.github.airmoment.flight.domain.Airline;
 import com.github.airmoment.flight.domain.enums.FlightSortOption;
 import com.github.airmoment.flight.dto.CachedFlightItem;
 import com.github.airmoment.flight.dto.CachedFlightResult;
+import com.github.airmoment.flight.dto.FlightFeatureVector;
 import com.github.airmoment.flight.dto.FlightItemResponse;
 import com.github.airmoment.flight.dto.FlightListResponse;
 import com.github.airmoment.flight.repository.AirlineRepository;
@@ -43,6 +44,7 @@ public class FlightSearchService {
 	private final AirlineRepository airlineRepository;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ObjectMapper objectMapper;
+	private final FlightFeatureService flightFeatureService;
 
 	@Transactional
 	public FlightListResponse searchFlights(
@@ -70,6 +72,9 @@ public class FlightSearchService {
 			.sorted(getComparator(effectiveSort))
 			.map(FlightItemResponse::from)
 			.toList();
+
+		FlightFeatureVector featureVector = flightFeatureService.calculate(departureCode, arrivalCode, departureAt, cached);
+		log.info("입력한 조건의 항공권 결과에 대한 feature vector 계산이 완료되었습니다. \n****FeatureVector****\n {}", featureVector);
 
 		return FlightListResponse.of(result);
 	}

--- a/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
@@ -1,0 +1,158 @@
+package com.github.airmoment.flight.service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.airmoment.flight.domain.Airline;
+import com.github.airmoment.flight.domain.enums.FlightSortOption;
+import com.github.airmoment.flight.dto.CachedFlightItem;
+import com.github.airmoment.flight.dto.CachedFlightResult;
+import com.github.airmoment.flight.dto.FlightItemResponse;
+import com.github.airmoment.flight.dto.FlightListResponse;
+import com.github.airmoment.flight.repository.AirlineRepository;
+import com.github.airmoment.global.client.serpapi.SerpApiClient;
+import com.github.airmoment.global.client.serpapi.dto.FlightOfferDto;
+import com.github.airmoment.global.client.serpapi.dto.FlightSearchResponse;
+import com.github.airmoment.global.client.serpapi.dto.FlightSegmentDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FlightSearchService {
+
+	private static final String CACHE_KEY_FORMAT = "flights:%s:%s:%s";
+	private static final Duration CACHE_TTL = Duration.ofHours(12);
+	private static final DateTimeFormatter SEGMENT_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+	private final SerpApiClient serpApiClient;
+	private final AirlineRepository airlineRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Transactional
+	public FlightListResponse searchFlights(
+		String departureCode,
+		String arrivalCode,
+		LocalDate departureAt,
+		FlightSortOption sort,
+		Boolean nonstopOnly,
+		Integer maxPrice
+	) {
+		String cacheKey = String.format(CACHE_KEY_FORMAT, departureCode, arrivalCode, departureAt);
+
+		CachedFlightResult cached = getFromCache(cacheKey);
+		if (cached == null) {
+			FlightSearchResponse response = serpApiClient.fetchFlights(departureCode, arrivalCode, departureAt.toString());
+			cached = buildCachedResult(response);
+			saveToCache(cacheKey, cached);
+		}
+
+		FlightSortOption effectiveSort = sort != null ? sort : FlightSortOption.DEPARTURE_TIME_ASC;
+
+		List<FlightItemResponse> result = cached.flights().stream()
+			.filter(item -> nonstopOnly == null || !nonstopOnly || item.nonstop())
+			.filter(item -> maxPrice == null || item.price() <= maxPrice)
+			.sorted(getComparator(effectiveSort))
+			.map(FlightItemResponse::from)
+			.toList();
+
+		return FlightListResponse.of(result);
+	}
+
+	private CachedFlightResult buildCachedResult(FlightSearchResponse response) {
+		List<FlightOfferDto> allOffers = new ArrayList<>();
+		if (response.bestFlights() != null) allOffers.addAll(response.bestFlights());
+		if (response.otherFlights() != null) allOffers.addAll(response.otherFlights());
+
+		List<CachedFlightItem> flights = allOffers.stream()
+			.filter(offer -> offer.price() != null
+				&& offer.flights() != null
+				&& !offer.flights().isEmpty())
+			.map(this::toCachedItem)
+			.toList();
+
+		Integer typicalPriceMin = null;
+		Integer typicalPriceMax = null;
+		if (response.priceInsights() != null && response.priceInsights().typicalPriceRange() != null
+			&& response.priceInsights().typicalPriceRange().size() >= 2) {
+			typicalPriceMin = response.priceInsights().typicalPriceRange().get(0);
+			typicalPriceMax = response.priceInsights().typicalPriceRange().get(1);
+		}
+
+		return new CachedFlightResult(flights, typicalPriceMin, typicalPriceMax);
+	}
+
+	private CachedFlightItem toCachedItem(FlightOfferDto offer) {
+		FlightSegmentDto firstSegment = offer.flights().get(0);
+		FlightSegmentDto lastSegment = offer.flights().get(offer.flights().size() - 1);
+
+		String airlineName = firstSegment.airline();
+		String airlinePhoto = resolveAirlinePhoto(airlineName);
+
+		LocalTime departureTime = parseTime(firstSegment.departureAirport().time());
+		LocalTime arrivalTime = parseTime(lastSegment.arrivalAirport().time());
+		boolean nonstop = offer.layovers() == null || offer.layovers().isEmpty();
+
+		return new CachedFlightItem(airlineName, airlinePhoto, departureTime, arrivalTime,
+			offer.totalDuration(), offer.price(), nonstop);
+	}
+
+	private String resolveAirlinePhoto(String airlineName) {
+		if (airlineName == null || airlineName.isBlank()) {
+			return null;
+		}
+		return airlineRepository.findByName(airlineName)
+			.orElseGet(() -> airlineRepository.save(Airline.of(airlineName)))
+			.getPhoto();
+	}
+
+	private LocalTime parseTime(String timeStr) {
+		if (timeStr == null || timeStr.isBlank()) return null;
+		return LocalDateTime.parse(timeStr, SEGMENT_TIME_FORMATTER).toLocalTime();
+	}
+
+	private Comparator<CachedFlightItem> getComparator(FlightSortOption sort) {
+		return switch (sort) {
+			case DEPARTURE_TIME_ASC ->
+				Comparator.comparing(CachedFlightItem::departureTime, Comparator.nullsLast(Comparator.naturalOrder()));
+			case DEPARTURE_TIME_DESC ->
+				Comparator.comparing(CachedFlightItem::departureTime, Comparator.nullsLast(Comparator.reverseOrder()));
+			case PRICE_ASC ->
+				Comparator.comparingInt(CachedFlightItem::price);
+		};
+	}
+
+	private CachedFlightResult getFromCache(String key) {
+		String json = redisTemplate.opsForValue().get(key);
+		if (json == null) return null;
+		try {
+			return objectMapper.readValue(json, CachedFlightResult.class);
+		} catch (JsonProcessingException e) {
+			log.warn("Redis 캐시 역직렬화 실패 - key: {}, error: {}", key, e.getMessage());
+			return null;
+		}
+	}
+
+	private void saveToCache(String key, CachedFlightResult result) {
+		try {
+			redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(result), CACHE_TTL);
+		} catch (JsonProcessingException e) {
+			log.warn("Redis 캐시 저장 실패 - key: {}, error: {}", key, e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
@@ -15,18 +15,23 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.airmoment.exception.FlightErrorCode;
 import com.github.airmoment.flight.domain.Airline;
 import com.github.airmoment.flight.domain.enums.FlightSortOption;
+import com.github.airmoment.flight.dto.AIPredictionResponse;
 import com.github.airmoment.flight.dto.CachedFlightItem;
 import com.github.airmoment.flight.dto.CachedFlightResult;
 import com.github.airmoment.flight.dto.FlightFeatureVector;
 import com.github.airmoment.flight.dto.FlightItemResponse;
 import com.github.airmoment.flight.dto.FlightListResponse;
+import com.github.airmoment.flight.dto.FlightPredictDto;
 import com.github.airmoment.flight.repository.AirlineRepository;
+import com.github.airmoment.global.client.fastapi.AIServerClient;
 import com.github.airmoment.global.client.serpapi.SerpApiClient;
 import com.github.airmoment.global.client.serpapi.dto.FlightOfferDto;
 import com.github.airmoment.global.client.serpapi.dto.FlightSearchResponse;
 import com.github.airmoment.global.client.serpapi.dto.FlightSegmentDto;
+import com.github.airmoment.global.exception.AirmomentException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +50,7 @@ public class FlightSearchService {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ObjectMapper objectMapper;
 	private final FlightFeatureService flightFeatureService;
+	private final AIServerClient aiServerClient;
 
 	@Transactional
 	public FlightListResponse searchFlights(
@@ -73,10 +79,28 @@ public class FlightSearchService {
 			.map(FlightItemResponse::from)
 			.toList();
 
+		// 입력값, 항공권 조회값을 바탕으로 featureVector 계산
 		FlightFeatureVector featureVector = flightFeatureService.calculate(departureCode, arrivalCode, departureAt, cached);
 		log.info("입력한 조건의 항공권 결과에 대한 feature vector 계산이 완료되었습니다. \n****FeatureVector****\n {}", featureVector);
 
-		return FlightListResponse.of(result);
+		AIPredictionResponse prediction = null;
+		try {
+			prediction = getPrediction(featureVector);
+		} catch (Exception e) {
+			log.error("AI 서버의 예측 API를 호출이 실패하였습니다.\nerror:{}", e.getMessage());
+		}
+
+		if (prediction != null) {
+			FlightPredictDto predictDto = new FlightPredictDto(prediction.decision());
+			return FlightListResponse.of(predictDto, result);
+		}
+		else {
+			throw new AirmomentException(FlightErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private AIPredictionResponse getPrediction(FlightFeatureVector featureVector) {
+		return aiServerClient.predict(featureVector);
 	}
 
 	private CachedFlightResult buildCachedResult(FlightSearchResponse response) {

--- a/src/main/java/com/github/airmoment/global/client/fastapi/AIServerClient.java
+++ b/src/main/java/com/github/airmoment/global/client/fastapi/AIServerClient.java
@@ -1,0 +1,25 @@
+package com.github.airmoment.global.client.fastapi;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.github.airmoment.flight.dto.AIPredictionResponse;
+import com.github.airmoment.flight.dto.FlightFeatureVector;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AIServerClient {
+
+	private final RestClient restClient;
+	private final AIServerProperties aiServerProperties;
+
+	public AIPredictionResponse predict(FlightFeatureVector featureVector) {
+		return restClient.post()
+			.uri(aiServerProperties.baseUrl() + "/predict")
+			.body(featureVector)
+			.retrieve()
+			.body(AIPredictionResponse.class);
+	}
+}

--- a/src/main/java/com/github/airmoment/global/client/fastapi/AIServerClient.java
+++ b/src/main/java/com/github/airmoment/global/client/fastapi/AIServerClient.java
@@ -1,19 +1,25 @@
 package com.github.airmoment.global.client.fastapi;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import com.github.airmoment.flight.dto.AIPredictionResponse;
 import com.github.airmoment.flight.dto.FlightFeatureVector;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
 public class AIServerClient {
 
 	private final RestClient restClient;
 	private final AIServerProperties aiServerProperties;
+
+	public AIServerClient(
+		@Qualifier("aiServerRestClient") RestClient restClient,
+		AIServerProperties aiServerProperties
+	) {
+		this.restClient = restClient;
+		this.aiServerProperties = aiServerProperties;
+	}
 
 	public AIPredictionResponse predict(FlightFeatureVector featureVector) {
 		return restClient.post()

--- a/src/main/java/com/github/airmoment/global/client/fastapi/AIServerProperties.java
+++ b/src/main/java/com/github/airmoment/global/client/fastapi/AIServerProperties.java
@@ -1,0 +1,7 @@
+package com.github.airmoment.global.client.fastapi;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "ai-server")
+public record AIServerProperties(String baseUrl) {}
+

--- a/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiClient.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiClient.java
@@ -30,6 +30,7 @@ public class SerpApiClient {
 				.queryParam("currency", "KRW")
 				.queryParam("hl", "ko")
 				.queryParam("gl", "kr")
+				.queryParam("travel_class", "1")
 				.build())
 			.retrieve()
 			.body(FlightSearchResponse.class);

--- a/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiClient.java
+++ b/src/main/java/com/github/airmoment/global/client/serpapi/SerpApiClient.java
@@ -30,7 +30,8 @@ public class SerpApiClient {
 				.queryParam("currency", "KRW")
 				.queryParam("hl", "ko")
 				.queryParam("gl", "kr")
-				.queryParam("travel_class", "1")
+				.queryParam("travel_class", "1") // ← 이코노미
+				.queryParam("deep_search", "true")
 				.build())
 			.retrieve()
 			.body(FlightSearchResponse.class);

--- a/src/main/java/com/github/airmoment/global/config/RedisConfig.java
+++ b/src/main/java/com/github/airmoment/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.github.airmoment.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/com/github/airmoment/global/config/WebConfig.java
+++ b/src/main/java/com/github/airmoment/global/config/WebConfig.java
@@ -1,5 +1,9 @@
 package com.github.airmoment.global.config;
 
+import java.time.Duration;
+
+import org.springframework.boot.web.client.ClientHttpRequestFactories;
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
@@ -15,6 +19,17 @@ public class WebConfig implements WebMvcConfigurer {
 	@Bean
 	public RestClient restClient() {
 		return RestClient.create();
+	}
+
+	@Bean
+	public RestClient aiServerRestClient() {
+		return RestClient.builder()
+			.requestFactory(ClientHttpRequestFactories.get(
+				ClientHttpRequestFactorySettings.DEFAULTS
+					.withConnectTimeout(Duration.ofSeconds(2))
+					.withReadTimeout(Duration.ofSeconds(5))
+			))
+			.build();
 	}
 
 	@Override


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #24

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
항공권 데이터의 경우, 조회하는 시점에 따라 결과값이 바뀌기 때문에 조회 결과를 db에 저장할 필요가 없다고 생각하여 redis를 사용하였습니다. 
redis caching으로 항공권 데이터에 필터 조회, 옵션 등의 추가 파라미터가 적용된 결과를 빠르게 반환합니다. 

전달받은 input feature description을 바탕으로, 입력 조건값 + 조회된 항공권 데이터 + 스케쥴러로 수집된 데이터베이스를 사용해 regression 모델에 input으로 넣을 feature vector를 계산하였습니다. 

RestClient를 사용해 FastAPI 서버의 /predict 엔드포인트를 연결하고, 반환값을 dto에 매핑하여 항공권 조회 API의 응답에 포함합니다. 

두 서버 (스프링부트 :8080, FastAPI:8000)는 각각  docker-compose로 구성하여 단일 인스턴스 내에서 별개의 컨테이너로 띄우도록 구성하였습니다. 다만, FastAPI의 이미지는 ECR에 올리지 않기 때문에 cd 과정에서 빌드가 필요합니다.  

SerpAPI를 호출할 때 좌석 등급이 이코노미인 항공권만 조회되도록 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="1163" height="707" alt="image" src="https://github.com/user-attachments/assets/95565f1e-9612-420f-9eed-0253f8d7e0c7" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
아 졸리당..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 항공권 검색 기능 추가: 출발지, 도착지, 날짜를 기준으로 항공권 검색 가능
  * 다양한 필터링 및 정렬 옵션: 가격, 출발 시간, 논스톱 필터링
  * AI 기반 항공권 가격 예측 기능 추가
  * 인천(ICN) 기준 주요 국제 노선 지원 (파리, 뉴욕, 시드니)

* **Performance Improvements**
  * 검색 결과 캐싱을 통한 응답 속도 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->