### PR TITLE
[fix] #24 - docker compose의 포트, 공개범위 수정

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,8 +22,8 @@ services:
 
   db:
     image: mysql:8.0
-    expose:
-      - "6379"
+    ports:
+      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: airmoment


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #24

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 개발 환경 데이터베이스 포트 설정이 업데이트되었습니다. 이제 호스트의 3306 포트에서 데이터베이스에 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->