### PR TITLE
[feat] #30 - member, interest 엔티티 작성

### DIFF
--- a/src/main/java/com/github/airmoment/flight/exception/FlightErrorCode.java
+++ b/src/main/java/com/github/airmoment/flight/exception/FlightErrorCode.java
@@ -1,4 +1,4 @@
-package com.github.airmoment.exception;
+package com.github.airmoment.flight.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
+++ b/src/main/java/com/github/airmoment/flight/service/FlightSearchService.java
@@ -13,7 +13,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.airmoment.exception.FlightErrorCode;
+import com.github.airmoment.flight.exception.FlightErrorCode;
 import com.github.airmoment.flight.domain.enums.FlightSortOption;
 import com.github.airmoment.flight.dto.AIPredictionResponse;
 import com.github.airmoment.flight.dto.CachedFlightItem;

--- a/src/main/java/com/github/airmoment/interest/domain/Interest.java
+++ b/src/main/java/com/github/airmoment/interest/domain/Interest.java
@@ -1,0 +1,51 @@
+package com.github.airmoment.interest.domain;
+
+import java.time.LocalDate;
+
+import com.github.airmoment.flight.domain.enums.AirportCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "interest")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Interest {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private AirportCode departureCode;
+
+	@Column(nullable = false)
+	private AirportCode arrivalCode;
+
+	@Column(nullable = false)
+	private LocalDate departureAt;
+
+	@Column(nullable = false)
+	private boolean isBookmarked;
+
+	@Column(nullable = false)
+	private boolean isEmailNotificationEnabled;
+
+	public static Interest of(AirportCode departureCode, AirportCode arrivalCode, LocalDate departureAt, boolean isBookmarked, boolean isEmailNotificationEnabled) {
+		Interest interest = new Interest();
+		interest.departureCode = departureCode;
+		interest.arrivalCode = arrivalCode;
+		interest.departureAt = departureAt;
+		interest.isBookmarked = isBookmarked;
+		interest.isEmailNotificationEnabled = isEmailNotificationEnabled;
+		return interest;
+	}
+}

--- a/src/main/java/com/github/airmoment/interest/domain/Interest.java
+++ b/src/main/java/com/github/airmoment/interest/domain/Interest.java
@@ -39,13 +39,17 @@ public class Interest {
 	@Column(nullable = false)
 	private boolean isEmailNotificationEnabled;
 
-	public static Interest of(AirportCode departureCode, AirportCode arrivalCode, LocalDate departureAt, boolean isBookmarked, boolean isEmailNotificationEnabled) {
+	@Column(nullable = false)
+	private Long memberId;
+
+	public static Interest of(AirportCode departureCode, AirportCode arrivalCode, LocalDate departureAt, boolean isBookmarked, boolean isEmailNotificationEnabled, Long memberId) {
 		Interest interest = new Interest();
 		interest.departureCode = departureCode;
 		interest.arrivalCode = arrivalCode;
 		interest.departureAt = departureAt;
 		interest.isBookmarked = isBookmarked;
 		interest.isEmailNotificationEnabled = isEmailNotificationEnabled;
+		interest.memberId = memberId;
 		return interest;
 	}
 }

--- a/src/main/java/com/github/airmoment/interest/domain/Interest.java
+++ b/src/main/java/com/github/airmoment/interest/domain/Interest.java
@@ -6,6 +6,8 @@ import com.github.airmoment.flight.domain.enums.AirportCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,9 +27,11 @@ public class Interest {
 	private Long id;
 
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
 	private AirportCode departureCode;
 
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
 	private AirportCode arrivalCode;
 
 	@Column(nullable = false)

--- a/src/main/java/com/github/airmoment/interest/repository/InterestRepository.java
+++ b/src/main/java/com/github/airmoment/interest/repository/InterestRepository.java
@@ -1,0 +1,8 @@
+package com.github.airmoment.interest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.airmoment.interest.domain.Interest;
+
+public interface InterestRepository extends JpaRepository<Interest, Long> {
+}

--- a/src/main/java/com/github/airmoment/member/domain/Member.java
+++ b/src/main/java/com/github/airmoment/member/domain/Member.java
@@ -23,7 +23,7 @@ public class Member {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(unique = true)
+	@Column(unique = true, nullable = false)
 	private String email;
 
 	@Column(nullable = false)

--- a/src/main/java/com/github/airmoment/member/domain/Member.java
+++ b/src/main/java/com/github/airmoment/member/domain/Member.java
@@ -1,0 +1,42 @@
+package com.github.airmoment.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	private static final String DEFAULT_PHOTO =
+		"https://www.logoyogo.com/web/wp-content/uploads/edd/2021/03/logoyogo-1-164.jpg";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(unique = true)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	private String profileImage;
+
+	public static Member of(String email, String password) {
+		Member member = new Member();
+		member.email = email;
+		member.password = password;
+		member.profileImage = DEFAULT_PHOTO;
+		return member;
+	}
+}

--- a/src/main/java/com/github/airmoment/member/repository/MemberRepository.java
+++ b/src/main/java/com/github/airmoment/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.github.airmoment.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.github.airmoment.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #30

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
로그인 정보(id, pwd)를 저장할 member 엔티티와 member를 fk로 갖는 interest 엔티티를 구성하였습니다. 
interest 엔티티에서는 노선에 대해 찜 여부, 이메일 수신 여부를 관리합니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자 계정 및 프로필 관리 기능 추가
  * 항공편 관심사 저장 및 북마크 기능 추가

* **리팩토링**
  * 내부 패키지 구조 개선으로 코드 조직화 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->