### PR TITLE
[feat] #31 - 회원가입, 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/github/airmoment/AirmomentApplication.java
+++ b/src/main/java/com/github/airmoment/AirmomentApplication.java
@@ -9,13 +9,15 @@ import com.github.airmoment.global.client.discord.DiscordProperties;
 import com.github.airmoment.global.client.fastapi.AIServerProperties;
 import com.github.airmoment.global.client.google.GoogleSheetsProperties;
 import com.github.airmoment.global.client.serpapi.SerpApiProperties;
+import com.github.airmoment.global.jwt.JwtProperties;
 
 @EnableScheduling
 @EnableConfigurationProperties({
 	SerpApiProperties.class,
 	DiscordProperties.class,
 	GoogleSheetsProperties.class,
-	AIServerProperties.class
+	AIServerProperties.class,
+	JwtProperties.class
 })
 @SpringBootApplication
 public class AirmomentApplication {

--- a/src/main/java/com/github/airmoment/global/config/SecurityConfig.java
+++ b/src/main/java/com/github/airmoment/global/config/SecurityConfig.java
@@ -7,12 +7,25 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.github.airmoment.global.jwt.JwtAuthenticationFilter;
+import com.github.airmoment.global.jwt.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtProvider jwtProvider;
+	private final UserDetailsService userDetailsService;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -22,9 +35,19 @@ public class SecurityConfig {
 				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
 			.authorizeHttpRequests(auth -> auth
-				.anyRequest().permitAll()
+				.requestMatchers("/api/v1/members/signup", "/api/v1/members/login", "/api/v1/members/refresh").permitAll()
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(
+				new JwtAuthenticationFilter(jwtProvider, userDetailsService),
+				UsernamePasswordAuthenticationFilter.class
 			);
 
 		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/github/airmoment/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/airmoment/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.github.airmoment.global.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtProvider jwtProvider;
+	private final UserDetailsService userDetailsService;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String token = extractToken(request);
+
+		if (token != null && jwtProvider.validate(token)) {
+			Long memberId = jwtProvider.getMemberId(token);
+			UserDetails userDetails = userDetailsService.loadUserByUsername(memberId.toString());
+			UsernamePasswordAuthenticationToken authentication =
+				new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String extractToken(HttpServletRequest request) {
+		String header = request.getHeader(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+			return header.substring(BEARER_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/github/airmoment/global/jwt/JwtProperties.java
+++ b/src/main/java/com/github/airmoment/global/jwt/JwtProperties.java
@@ -1,0 +1,11 @@
+package com.github.airmoment.global.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+	String secret,
+	long accessTokenExpiry,
+	long refreshTokenExpiry
+) {
+}

--- a/src/main/java/com/github/airmoment/global/jwt/JwtProvider.java
+++ b/src/main/java/com/github/airmoment/global/jwt/JwtProvider.java
@@ -1,0 +1,69 @@
+package com.github.airmoment.global.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+	private final SecretKey secretKey;
+	private final long accessTokenExpiry;
+	private final long refreshTokenExpiry;
+
+	public JwtProvider(JwtProperties properties) {
+		this.secretKey = Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+		this.accessTokenExpiry = properties.accessTokenExpiry();
+		this.refreshTokenExpiry = properties.refreshTokenExpiry();
+	}
+
+	public String createAccessToken(Long memberId) {
+		return createToken(memberId, accessTokenExpiry);
+	}
+
+	public String createRefreshToken(Long memberId) {
+		return createToken(memberId, refreshTokenExpiry);
+	}
+
+	public Long getMemberId(String token) {
+		return parseClaims(token).get("memberId", Long.class);
+	}
+
+	public boolean validate(String token) {
+		try {
+			parseClaims(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			log.debug("유효하지 않은 JWT: {}", e.getMessage());
+			return false;
+		}
+	}
+
+	private String createToken(Long memberId, long expiry) {
+		Date now = new Date();
+		return Jwts.builder()
+			.claim("memberId", memberId)
+			.issuedAt(now)
+			.expiration(new Date(now.getTime() + expiry))
+			.signWith(secretKey)
+			.compact();
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(secretKey)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+}

--- a/src/main/java/com/github/airmoment/member/domain/Member.java
+++ b/src/main/java/com/github/airmoment/member/domain/Member.java
@@ -30,12 +30,16 @@ public class Member {
 	private String password;
 
 	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
 	private String profileImage;
 
-	public static Member of(String email, String password) {
+	public static Member of(String email, String password, String name) {
 		Member member = new Member();
 		member.email = email;
 		member.password = password;
+		member.name = name;
 		member.profileImage = DEFAULT_PHOTO;
 		return member;
 	}

--- a/src/main/java/com/github/airmoment/member/dto/LoginRequest.java
+++ b/src/main/java/com/github/airmoment/member/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.github.airmoment.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+	@NotBlank @Email
+	String email,
+
+	@NotBlank
+	String password
+) {
+}

--- a/src/main/java/com/github/airmoment/member/dto/RefreshRequest.java
+++ b/src/main/java/com/github/airmoment/member/dto/RefreshRequest.java
@@ -1,0 +1,9 @@
+package com.github.airmoment.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+	@NotBlank
+	String refreshToken
+) {
+}

--- a/src/main/java/com/github/airmoment/member/dto/SignupRequest.java
+++ b/src/main/java/com/github/airmoment/member/dto/SignupRequest.java
@@ -1,0 +1,13 @@
+package com.github.airmoment.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+	@NotBlank @Email
+	String email,
+
+	@NotBlank
+	String password
+) {
+}

--- a/src/main/java/com/github/airmoment/member/dto/SignupRequest.java
+++ b/src/main/java/com/github/airmoment/member/dto/SignupRequest.java
@@ -8,6 +8,9 @@ public record SignupRequest(
 	String email,
 
 	@NotBlank
-	String password
+	String password,
+
+	@NotBlank
+	String name
 ) {
 }

--- a/src/main/java/com/github/airmoment/member/dto/TokenResponse.java
+++ b/src/main/java/com/github/airmoment/member/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.github.airmoment.member.dto;
+
+public record TokenResponse(
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/github/airmoment/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/github/airmoment/member/exception/MemberErrorCode.java
@@ -1,0 +1,22 @@
+package com.github.airmoment.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.airmoment.global.response.base.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements BaseCode {
+
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/github/airmoment/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/github/airmoment/member/exception/MemberSuccessCode.java
@@ -1,0 +1,21 @@
+package com.github.airmoment.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.github.airmoment.global.response.base.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSuccessCode implements BaseCode {
+
+	SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입이 완료되었습니다."),
+	LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),
+	REFRESH_SUCCESS(HttpStatus.OK, "토큰이 재발급되었습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/github/airmoment/member/presentation/MemberController.java
+++ b/src/main/java/com/github/airmoment/member/presentation/MemberController.java
@@ -1,0 +1,46 @@
+package com.github.airmoment.member.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.airmoment.global.response.dto.SuccessResponse;
+import com.github.airmoment.member.dto.LoginRequest;
+import com.github.airmoment.member.dto.RefreshRequest;
+import com.github.airmoment.member.dto.SignupRequest;
+import com.github.airmoment.member.dto.TokenResponse;
+import com.github.airmoment.member.exception.MemberSuccessCode;
+import com.github.airmoment.member.service.MemberService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<SuccessResponse<Void>> signup(@Valid @RequestBody SignupRequest request) {
+		memberService.signup(request);
+		return ResponseEntity
+			.status(MemberSuccessCode.SIGNUP_SUCCESS.getHttpStatus())
+			.body(SuccessResponse.of(MemberSuccessCode.SIGNUP_SUCCESS));
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<SuccessResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+		TokenResponse tokens = memberService.login(request);
+		return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.LOGIN_SUCCESS, tokens));
+	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<SuccessResponse<TokenResponse>> refresh(@Valid @RequestBody RefreshRequest request) {
+		TokenResponse tokens = memberService.refresh(request);
+		return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.REFRESH_SUCCESS, tokens));
+	}
+}

--- a/src/main/java/com/github/airmoment/member/repository/MemberRepository.java
+++ b/src/main/java/com/github/airmoment/member/repository/MemberRepository.java
@@ -1,8 +1,14 @@
 package com.github.airmoment.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.airmoment.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByEmail(String email);
+
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/github/airmoment/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/github/airmoment/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,29 @@
+package com.github.airmoment.member.repository;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+	private static final String KEY_PREFIX = "refresh:";
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void save(Long memberId, String refreshToken, Duration ttl) {
+		redisTemplate.opsForValue().set(KEY_PREFIX + memberId, refreshToken, ttl);
+	}
+
+	public String find(Long memberId) {
+		return redisTemplate.opsForValue().get(KEY_PREFIX + memberId);
+	}
+
+	public void delete(Long memberId) {
+		redisTemplate.delete(KEY_PREFIX + memberId);
+	}
+}

--- a/src/main/java/com/github/airmoment/member/service/MemberDetailsService.java
+++ b/src/main/java/com/github/airmoment/member/service/MemberDetailsService.java
@@ -1,0 +1,31 @@
+package com.github.airmoment.member.service;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.github.airmoment.member.domain.Member;
+import com.github.airmoment.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailsService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
+		Member member = memberRepository.findById(Long.parseLong(memberId))
+			.orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다: " + memberId));
+
+		return User.builder()
+			.username(member.getId().toString())
+			.password(member.getPassword())
+			.roles("USER")
+			.build();
+	}
+}

--- a/src/main/java/com/github/airmoment/member/service/MemberService.java
+++ b/src/main/java/com/github/airmoment/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
 			throw new AirmomentException(MemberErrorCode.DUPLICATE_EMAIL);
 		}
 
-		Member member = Member.of(request.email(), passwordEncoder.encode(request.password()));
+		Member member = Member.of(request.email(), passwordEncoder.encode(request.password()), request.name());
 		memberRepository.save(member);
 	}
 

--- a/src/main/java/com/github/airmoment/member/service/MemberService.java
+++ b/src/main/java/com/github/airmoment/member/service/MemberService.java
@@ -1,0 +1,79 @@
+package com.github.airmoment.member.service;
+
+import java.time.Duration;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.github.airmoment.global.exception.AirmomentException;
+import com.github.airmoment.global.jwt.JwtProperties;
+import com.github.airmoment.global.jwt.JwtProvider;
+import com.github.airmoment.member.domain.Member;
+import com.github.airmoment.member.dto.LoginRequest;
+import com.github.airmoment.member.dto.RefreshRequest;
+import com.github.airmoment.member.dto.SignupRequest;
+import com.github.airmoment.member.dto.TokenResponse;
+import com.github.airmoment.member.exception.MemberErrorCode;
+import com.github.airmoment.member.repository.MemberRepository;
+import com.github.airmoment.member.repository.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtProvider jwtProvider;
+	private final JwtProperties jwtProperties;
+
+	@Transactional
+	public void signup(SignupRequest request) {
+		if (memberRepository.existsByEmail(request.email())) {
+			throw new AirmomentException(MemberErrorCode.DUPLICATE_EMAIL);
+		}
+
+		Member member = Member.of(request.email(), passwordEncoder.encode(request.password()));
+		memberRepository.save(member);
+	}
+
+	@Transactional(readOnly = true)
+	public TokenResponse login(LoginRequest request) {
+		Member member = memberRepository.findByEmail(request.email())
+			.orElseThrow(() -> new AirmomentException(MemberErrorCode.INVALID_CREDENTIALS));
+
+		if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+			throw new AirmomentException(MemberErrorCode.INVALID_CREDENTIALS);
+		}
+
+		return issueTokens(member.getId());
+	}
+
+	public TokenResponse refresh(RefreshRequest request) {
+		String refreshToken = request.refreshToken();
+
+		if (!jwtProvider.validate(refreshToken)) {
+			throw new AirmomentException(MemberErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		Long memberId = jwtProvider.getMemberId(refreshToken);
+		String stored = refreshTokenRepository.find(memberId);
+
+		if (!refreshToken.equals(stored)) {
+			throw new AirmomentException(MemberErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		return issueTokens(memberId);
+	}
+
+	private TokenResponse issueTokens(Long memberId) {
+		String accessToken = jwtProvider.createAccessToken(memberId);
+		String refreshToken = jwtProvider.createRefreshToken(memberId);
+		refreshTokenRepository.save(memberId, refreshToken,
+			Duration.ofMillis(jwtProperties.refreshTokenExpiry()));
+		return new TokenResponse(accessToken, refreshToken);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #31

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
JWT 기반 email, password로 회원가입 및 로그인을 진행하는 API를 구현하였습니다. refresh 재발급 엔드포인트도 구현되어 있으나, 프론트 담당 팀원분이 토큰 만료 체크 -> 토큰 재발급 과정에서 어려움을 느끼실 수도 있을 것 같아, access token의 만료시간을 매우 길게 설정해놓아 refresh token을 사용할 일은 없을 것 같습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="859" height="489" alt="image" src="https://github.com/user-attachments/assets/ee4e8793-463a-428b-ba9c-4fa22ce557fe" />

<img width="848" height="614" alt="image" src="https://github.com/user-attachments/assets/5a8baeb0-2e07-4a91-9504-5d42eece9ad5" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
