### PR TITLE
[feat] #38 - 마이페이지 조회 api 구현

### DIFF
--- a/src/main/java/com/github/airmoment/interest/dto/MyPageInterestDto.java
+++ b/src/main/java/com/github/airmoment/interest/dto/MyPageInterestDto.java
@@ -1,0 +1,47 @@
+package com.github.airmoment.interest.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import com.github.airmoment.flight.dto.GraphResponse;
+import com.github.airmoment.flight.dto.PredictionPoint;
+
+public record MyPageInterestDto(
+	String departureCode,
+	String arrivalCode,
+	LocalDate departureAt,
+	String departureDayOfWeek,
+	boolean nonStopOnly,
+	boolean isBookmarked,
+	boolean isEmailNotificationEnabled,
+	List<PredictionPoint> predictions,
+	ZonedDateTime predictedAt
+) {
+	public static MyPageInterestDto of(InterestDto interest, GraphResponse graphResponse) {
+		return new MyPageInterestDto(
+			interest.departureCode().name(),
+			interest.arrivalCode().name(),
+			interest.departureAt(),
+			toKoreanDayOfWeek(interest.departureAt().getDayOfWeek()),
+			interest.nonstopOnly(),
+			interest.isBookmarked(),
+			interest.isEmailNotificationEnabled(),
+			graphResponse != null ? graphResponse.predictions() : null,
+			graphResponse != null ? graphResponse.predictedAt() : null
+		);
+	}
+
+	private static String toKoreanDayOfWeek(DayOfWeek dayOfWeek) {
+		return switch (dayOfWeek) {
+			case MONDAY -> "월";
+			case TUESDAY -> "화";
+			case WEDNESDAY -> "수";
+			case THURSDAY -> "목";
+			case FRIDAY -> "금";
+			case SATURDAY -> "토";
+			case SUNDAY -> "일";
+		};
+	}
+}

--- a/src/main/java/com/github/airmoment/interest/dto/MyPageResponse.java
+++ b/src/main/java/com/github/airmoment/interest/dto/MyPageResponse.java
@@ -1,0 +1,6 @@
+package com.github.airmoment.interest.dto;
+
+import java.util.List;
+
+public record MyPageResponse(List<MyPageInterestDto> interests) {
+}

--- a/src/main/java/com/github/airmoment/interest/presentation/MyPageController.java
+++ b/src/main/java/com/github/airmoment/interest/presentation/MyPageController.java
@@ -1,0 +1,31 @@
+package com.github.airmoment.interest.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.airmoment.global.response.dto.SuccessResponse;
+import com.github.airmoment.interest.dto.MyPageResponse;
+import com.github.airmoment.interest.service.MyPageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+	private final MyPageService myPageService;
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<MyPageResponse>> getMyPage(
+		@AuthenticationPrincipal UserDetails userDetails
+	) {
+		Long memberId = Long.parseLong(userDetails.getUsername());
+		MyPageResponse response = myPageService.getMyPage(memberId);
+		return ResponseEntity.ok(new SuccessResponse<>(200, "마이페이지 조회에 성공하였습니다.", response));
+	}
+}

--- a/src/main/java/com/github/airmoment/interest/service/MyPageService.java
+++ b/src/main/java/com/github/airmoment/interest/service/MyPageService.java
@@ -1,0 +1,48 @@
+package com.github.airmoment.interest.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.github.airmoment.flight.dto.CachedFlightResult;
+import com.github.airmoment.flight.dto.GraphResponse;
+import com.github.airmoment.flight.service.FlightForecastService;
+import com.github.airmoment.flight.service.FlightSearchService;
+import com.github.airmoment.interest.dto.InterestDto;
+import com.github.airmoment.interest.dto.MyPageInterestDto;
+import com.github.airmoment.interest.dto.MyPageResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+	private final InterestService interestService;
+	private final FlightSearchService flightSearchService;
+	private final FlightForecastService flightForecastService;
+
+	public MyPageResponse getMyPage(Long memberId) {
+		List<InterestDto> interests = interestService.getInterests(memberId);
+
+		List<MyPageInterestDto> items = interests.stream()
+			.map(interest -> {
+				GraphResponse graphResponse = null;
+				try {
+					String dep = interest.departureCode().name();
+					String arr = interest.arrivalCode().name();
+					CachedFlightResult cached = flightSearchService.getCachedOrFetchResult(dep, arr, interest.departureAt());
+					graphResponse = flightForecastService.forecast(dep, arr, interest.departureAt(), cached);
+				} catch (Exception e) {
+					log.warn("노선 예측 실패 - {}-{} ({}): {}",
+						interest.departureCode(), interest.arrivalCode(), interest.departureAt(), e.getMessage());
+				}
+				return MyPageInterestDto.of(interest, graphResponse);
+			})
+			.toList();
+
+		return new MyPageResponse(items);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #38

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 관심 노선, 알림 수신을 설정한 노선, 노선 별 미래 가격밴드 예측값을 포함하여 반환합니다.
- 캐시된 데이터를 활용하고, 캐시된 데이터가 없을 시 SerpAPI로 항공권 가격 응답을 요청하기 때문에 시간이 소요될 수 있습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
